### PR TITLE
Windows OS detection improvements

### DIFF
--- a/app/lib/actions/foreman_wreckingball/host/remediate_vmware_operatingsystem.rb
+++ b/app/lib/actions/foreman_wreckingball/host/remediate_vmware_operatingsystem.rb
@@ -39,8 +39,8 @@ module Actions
           }
 
           desired_os = VsphereOsIdentifiers.find_by(selectors)
-          desired_os ||= VsphereOsIdentifiers.find_by(selectors.except(:release))
           desired_os ||= VsphereOsIdentifiers.find_by(selectors.except(:major))
+          desired_os ||= VsphereOsIdentifiers.find_by(selectors.except(:release))
           desired_os ||= VsphereOsIdentifiers.find_by(selectors.except(:major, :release))
           desired_os ||= VsphereOsIdentifiers.find_by(selectors.except(:major, :name))
           desired_os ||= VsphereOsIdentifiers.find_by(selectors.except(:major, :name, :release))

--- a/app/lib/actions/foreman_wreckingball/host/remediate_vmware_operatingsystem.rb
+++ b/app/lib/actions/foreman_wreckingball/host/remediate_vmware_operatingsystem.rb
@@ -34,12 +34,16 @@ module Actions
             :architecture => host.architecture.name,
             :osfamily => host.operatingsystem.family,
             :name => host.operatingsystem.name,
-            :major => host.operatingsystem.major.to_i
+            :major => host.operatingsystem.major.to_i,
+            :release => host.facts['os::release::full']
           }
 
           desired_os = VsphereOsIdentifiers.find_by(selectors)
+          desired_os ||= VsphereOsIdentifiers.find_by(selectors.except(:release))
           desired_os ||= VsphereOsIdentifiers.find_by(selectors.except(:major))
+          desired_os ||= VsphereOsIdentifiers.find_by(selectors.except(:major, :release))
           desired_os ||= VsphereOsIdentifiers.find_by(selectors.except(:major, :name))
+          desired_os ||= VsphereOsIdentifiers.find_by(selectors.except(:major, :name, :release))
 
           fail _('Could not auto detect desired operatingsystem.') unless desired_os
 

--- a/app/lib/vsphere_os_identifiers.rb
+++ b/app/lib/vsphere_os_identifiers.rb
@@ -20,9 +20,9 @@ module VsphereOsIdentifiers
     found = all
 
     selectors.each do |selector, value|
-      next unless selectors.key?(selector) and !value.nil?
+      next unless selectors.key?(selector) && !value.nil?
 
-      found.select! { |os| os.public_send(selector) && Array.new(os.public_send(selector)).flatten.include?(value) }
+      found.select! { |os| os.public_send(selector) && [os.public_send(selector)].flatten.include?(value) }
     end
     found
   end

--- a/app/lib/vsphere_os_identifiers.rb
+++ b/app/lib/vsphere_os_identifiers.rb
@@ -25,7 +25,7 @@ module VsphereOsIdentifiers
         test = os.public_send(selector)
         next unless test
 
-        case test.class
+        case test
         when Array
           test.include? value
         else

--- a/app/lib/vsphere_os_identifiers.rb
+++ b/app/lib/vsphere_os_identifiers.rb
@@ -20,18 +20,9 @@ module VsphereOsIdentifiers
     found = all
 
     selectors.each do |selector, value|
-      next unless selectors.key?(selector)
-      found.select! do |os|
-        test = os.public_send(selector)
-        next unless test
+      next unless selectors.key?(selector) and !value.nil?
 
-        case test
-        when Array
-          test.include? value
-        else
-          test == value
-        end
-      end
+      found.select! { |os| os.public_send(selector) && Array.new(os.public_send(selector)).flatten.include?(value) }
     end
     found
   end

--- a/app/lib/vsphere_os_identifiers.rb
+++ b/app/lib/vsphere_os_identifiers.rb
@@ -21,7 +21,17 @@ module VsphereOsIdentifiers
 
     selectors.each do |selector, value|
       next unless selectors.key?(selector)
-      found.select! { |os| os.public_send(selector) && os.public_send(selector) == value }
+      found.select! do |os|
+        test = os.public_send(selector)
+        next unless test
+
+        case test.class
+        when Array
+          test.include? value
+        else
+          test == value
+        end
+      end
     end
     found
   end

--- a/app/lib/vsphere_os_identifiers/data.yaml
+++ b/app/lib/vsphere_os_identifiers/data.yaml
@@ -534,7 +534,7 @@ windows7Server64Guest:
   :name: windows
   :osfamily: Windows
   :release:
-    - 2008
+    - '2008'
     - 2008 R2
   :since: 4.0
 windows7_64Guest:
@@ -558,7 +558,7 @@ windows8Server64Guest:
   :name: windows
   :osfamily: Windows
   :release:
-    - 2012
+    - '2012'
     - 2012 R2
   :since: 5.0
 windows8_64Guest:
@@ -582,7 +582,7 @@ windows9Server64Guest:
   :name: windows
   :osfamily: Windows
   :release:
-    - 2016
+    - '2016'
     - 2016 R2
   :since: 6.0
 windows9_64Guest:

--- a/app/lib/vsphere_os_identifiers/data.yaml
+++ b/app/lib/vsphere_os_identifiers/data.yaml
@@ -436,103 +436,163 @@ vmwarePhoton64Guest:
 
 win2000AdvServGuest:
   :description: Microsoft Windows 2000 Advanced Server
+  :name: windows
 win2000ProGuest:
   :description: Microsoft Windows 2000 Professional
+  :name: windows
 win2000ServGuest:
   :description: Microsoft Windows 2000 Server
+  :name: windows
 win31Guest:
   :description: Microsoft Windows 3.1
+  :name: windows
 win95Guest:
   :description: Microsoft Windows 95
+  :name: windows
 win98Guest:
   :description: Microsoft Windows 98
+  :name: windows
 winLonghorn64Guest:
   :description: Microsoft Windows Longhorn (64-bit)
   :architecture: x86_64
   :since: 2.5
+  :name: windows
 winLonghornGuest:
   :description: Microsoft Windows Longhorn (32-bit)
   :architecture: i386
   :since: 2.5
+  :name: windows
 winMeGuest:
   :description: Microsoft Windows Millenium Edition
+  :name: windows
 winNTGuest:
   :description: Microsoft Windows NT
+  :name: windows
 winNetBusinessGuest:
   :description: Microsoft Windows Small Business Server 2003
+  :name: windows
 winNetDatacenter64Guest:
   :description: Microsoft Windows Server 2003 Datacenter Edition (64-bit)
-  :architecture: x86_64
+  :architecture: x64
   :since: 2.5
+  :name: windows
 winNetDatacenterGuest:
   :description: Microsoft Windows Server 2003 Datacenter Edition (32-bit)
   :architecture: i386
   :since: 2.5
+  :name: windows
 winNetEnterprise64Guest:
   :description: Microsoft Windows Server 2003 Enterprise Edition (64-bit)
   :architecture: x86_64
+  :name: windows
 winNetEnterpriseGuest:
   :description: Microsoft Windows Server 2003 Enterprise Edition (32-bit)
   :architecture: i386
+  :name: windows
 winNetStandard64Guest:
   :description: Microsoft Windows Server 2003 Standard Edition (64-bit)
   :architecture: x86_64
+  :name: windows
 winNetStandardGuest:
   :description: Microsoft Windows Server 2003 Standard Edition (32-bit)
   :architecture: i386
+  :name: windows
 winNetWebGuest:
   :description: Microsoft Windows Server 2003 Web Edition (32-bit)
   :architecture: i386
+  :name: windows
 winVista64Guest:
   :description: Microsoft Windows Vista (64-bit)
   :architecture: x86_64
+  :name: windows
 winVistaGuest:
   :description: Microsoft Windows Vista (32-bit)
   :architecture: i386
+  :name: windows
 winXPHomeGuest:
   :description: Microsoft Windows XP Home Edition
+  :name: windows
 winXPPro64Guest:
   :description: Microsoft Windows XP Professional (64-bit)
   :architecture: x86_64
+  :name: windows
 winXPProGuest:
   :description: Microsoft Windows XP Professional (32-bit)
   :architecture: i386
+  :name: windows
 windows7Guest:
   :description: Microsoft Windows 7 (32-bit)
   :architecture: i386
+  :major: 6
+  :name: windows
+  :osfamily: Windows
   :since: 4.0
 windows7Server64Guest:
-  :description: Microsoft Windows Server 2008 R2 (64-bit)
-  :architecture: x86_64
+  :description: Microsoft Windows Server 2008/2008 R2 (64-bit)
+  :architecture: x64
+  :major: 6
+  :name: windows
+  :osfamily: Windows
+  :release:
+    - 2008
+    - 2008 R2
   :since: 4.0
 windows7_64Guest:
   :description: Microsoft Windows 7 (64-bit)
-  :architecture: x86_64
+  :architecture: x64
+  :major: 6
+  :name: windows
+  :osfamily: Windows
   :since: 4.0
 windows8Guest:
   :description: Microsoft Windows 8 (32-bit)
   :architecture: i386
+  :major: 6
+  :name: windows
+  :osfamily: Windows
   :since: 5.0
 windows8Server64Guest:
-  :description: Microsoft Windows Server 2012 (64-bit)
-  :architecture: x86_64
+  :description: Microsoft Windows Server 2012/2012 R2 (64-bit)
+  :architecture: x64
+  :major: 6
+  :name: windows
+  :osfamily: Windows
+  :release:
+    - 2012
+    - 2012 R2
   :since: 5.0
 windows8_64Guest:
   :description: Microsoft Windows 8 (64-bit)
-  :architecture: x86_64
+  :architecture: x64
+  :major: 6
+  :name: windows
+  :osfamily: Windows
   :since: 5.0
 windows9Guest:
   :description: Microsoft Windows 10 (32-bit)
   :architecture: i386
+  :major: 10
+  :name: windows
+  :osfamily: Windows
   :since: 6.0
 windows9Server64Guest:
-  :description: Microsoft Windows 10 Server (64 bit)
-  :architecture: x86_64
+  :description: Microsoft Windows Server 2016/2016 R2 (64 bit)
+  :architecture: x64
+  :major: 10
+  :name: windows
+  :osfamily: Windows
+  :release:
+    - 2016
+    - 2016 R2
   :since: 6.0
 windows9_64Guest:
   :description: Microsoft Windows 10 (64-bit)
-  :architecture: x86_64
+  :architecture: x64
+  :major: 10
+  :name: windows
+  :osfamily: Windows
   :since: 6.0
 windowsHyperVGuest:
   :description: Microsoft Windows Hyper-V
+  :name: windows
   :since: 5.5

--- a/app/lib/vsphere_os_identifiers/os.rb
+++ b/app/lib/vsphere_os_identifiers/os.rb
@@ -1,6 +1,6 @@
 module VsphereOsIdentifiers
   class Os
-    attr_reader :id, :description, :architecture, :since, :osfamily, :major, :name
+    attr_reader :id, :description, :architecture, :since, :osfamily, :major, :name, :release
 
     def initialize(id, opts = {})
       @id = id.to_s
@@ -10,6 +10,7 @@ module VsphereOsIdentifiers
       @osfamily = opts.fetch(:osfamily, nil)
       @name = opts.fetch(:name, nil)
       @major = opts.fetch(:major, nil)
+      @release = opts.fetch(:release, nil)
     end
 
     def ==(other)

--- a/app/models/foreman_wreckingball/operatingsystem_status.rb
+++ b/app/models/foreman_wreckingball/operatingsystem_status.rb
@@ -58,6 +58,7 @@ module ForemanWreckingball
       return false if vsphere_os.osfamily && vsphere_os.osfamily != host.operatingsystem.family
       return false if vsphere_os.name && vsphere_os.name != host.operatingsystem.name
       return false if vsphere_os.major && vsphere_os.major != host.operatingsystem.major.to_i
+      return false if vsphere_os.release && [vsphere_os.release].flatten.include?(host.facts['os::release::full'])
       true
     end
   end

--- a/app/models/foreman_wreckingball/operatingsystem_status.rb
+++ b/app/models/foreman_wreckingball/operatingsystem_status.rb
@@ -58,7 +58,7 @@ module ForemanWreckingball
       return false if vsphere_os.osfamily && vsphere_os.osfamily != host.operatingsystem.family
       return false if vsphere_os.name && vsphere_os.name != host.operatingsystem.name
       return false if vsphere_os.major && vsphere_os.major != host.operatingsystem.major.to_i
-      return false if vsphere_os.release && [vsphere_os.release].flatten.include?(host.facts['os::release::full'])
+      return false if vsphere_os.release && ![vsphere_os.release].flatten.include?(host.facts['os::release::full'])
       true
     end
   end


### PR DESCRIPTION
Improves the support for handling of - at least - Windows Server 2008 & R2, 2012 & R2, and 2016.

Will need to grab some os fact dumps from a few more machines before I can finish the rest of the Windowses.