### PR TITLE
Fix detection for CentOS 4/5

### DIFF
--- a/app/lib/vsphere_os_identifiers/data.yaml
+++ b/app/lib/vsphere_os_identifiers/data.yaml
@@ -32,6 +32,9 @@ centos64Guest:
   :since: 6.1
   :osfamily: Redhat
   :name: CentOS
+  :major:
+    - 4
+    - 5
 centos6Guest:
   :description: CentOS 6 (32-bit)
   :architecture: i386
@@ -59,6 +62,9 @@ centosGuest:
   :since: 4.1
   :osfamily: Redhat
   :name: CentOS
+  :major:
+    - 4
+    - 5
 coreos64Guest:
   :description: CoreOS Linux (64-bit)
   :architecture: x86_64

--- a/app/models/foreman_wreckingball/operatingsystem_status.rb
+++ b/app/models/foreman_wreckingball/operatingsystem_status.rb
@@ -57,7 +57,7 @@ module ForemanWreckingball
       return false if vsphere_os.architecture && vsphere_os.architecture != host.architecture.name
       return false if vsphere_os.osfamily && vsphere_os.osfamily != host.operatingsystem.family
       return false if vsphere_os.name && vsphere_os.name != host.operatingsystem.name
-      return false if vsphere_os.major && vsphere_os.major != host.operatingsystem.major.to_i
+      return false if vsphere_os.major && ![vsphere_os.major].flatten.include?(host.operatingsystem.major.to_i)
       return false if vsphere_os.release && ![vsphere_os.release].flatten.include?(host.facts['os::release::full'])
       true
     end


### PR DESCRIPTION
Without major versions specified, wreckingball will throw away the version check entirely, grabbing the topmost CentOS OS from the data and then not succeeding in the OS matching either way. (Major 6 of centos6_64Guest is - in fact - not identical to 5/4)