### PR TITLE
Fix compiling assets in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require Rails.root.join('config', 'environments', 'production.rb')
+
+Foreman::Application.configure do
+  config.assets.js_compressor = Uglifier.new(harmony: true)
+end


### PR DESCRIPTION
Fix #52 
With this patch I am able to run `rake 'plugin:assets:precompile[foreman_wreckingball]' RAILS_ENV=production` without any errors