### PR TITLE
Refactor dashboard status query

### DIFF
--- a/app/controllers/foreman_wreckingball/hosts_controller.rb
+++ b/app/controllers/foreman_wreckingball/hosts_controller.rb
@@ -27,12 +27,15 @@ module ForemanWreckingball
       @newest_data = Host.authorized(:view_hosts, Host).joins(:vmware_facet).maximum('vmware_facets.updated_at')
       @data = statuses.map do |status|
         host_association = status.host_association
-        counter = Host.authorized(:view_hosts, Host)
-                      .joins(host_association)
-                      .includes(host_association)
-                      .map { |host| host.public_send(host_association).to_global }
-                      .group_by { |global_status| global_status }
-                      .each_with_object({}) { |(global_status, items), hash| hash[global_status] = items.size }
+
+        # Let the database calculate status counts, then map to HostStatus::Global values
+        counter = Host.authorized(:view_hosts).
+                       joins(host_association).
+                       select('host_status.status').
+                       group('host_status.status').
+                       count.
+                       inject({}) { |r, (k,v)| r[status.to_global(k)] = v; r }
+
         {
           name: status.status_name,
           description: status.description,

--- a/app/models/foreman_wreckingball/cpu_hot_add_status.rb
+++ b/app/models/foreman_wreckingball/cpu_hot_add_status.rb
@@ -26,6 +26,10 @@ module ForemanWreckingball
     end
 
     def to_global(_options = {})
+      CpuHotAddStatus.to_global(status)
+    end
+
+    def self.to_global(status)
       case status
       when PERFORMANCE_DEGRATION
         HostStatus::Global::ERROR

--- a/app/models/foreman_wreckingball/cpu_hot_add_status.rb
+++ b/app/models/foreman_wreckingball/cpu_hot_add_status.rb
@@ -26,7 +26,7 @@ module ForemanWreckingball
     end
 
     def to_global(_options = {})
-      CpuHotAddStatus.to_global(status)
+      self.class.to_global(status)
     end
 
     def self.to_global(status)

--- a/app/models/foreman_wreckingball/hardware_version_status.rb
+++ b/app/models/foreman_wreckingball/hardware_version_status.rb
@@ -34,6 +34,10 @@ module ForemanWreckingball
     end
 
     def to_global(_options = {})
+      HardwareVersionStatus.to_global(status)
+    end
+
+    def self.to_global(status)
       case status
       when OUTOFDATE
         HostStatus::Global::WARN

--- a/app/models/foreman_wreckingball/hardware_version_status.rb
+++ b/app/models/foreman_wreckingball/hardware_version_status.rb
@@ -34,7 +34,7 @@ module ForemanWreckingball
     end
 
     def to_global(_options = {})
-      HardwareVersionStatus.to_global(status)
+      self.class.to_global(status)
     end
 
     def self.to_global(status)

--- a/app/models/foreman_wreckingball/operatingsystem_status.rb
+++ b/app/models/foreman_wreckingball/operatingsystem_status.rb
@@ -34,7 +34,7 @@ module ForemanWreckingball
     end
 
     def to_global(_options = {})
-      OperatingsystemStatus.to_global(status)
+      self.class.to_global(status)
     end
 
     def self.to_global(status)

--- a/app/models/foreman_wreckingball/operatingsystem_status.rb
+++ b/app/models/foreman_wreckingball/operatingsystem_status.rb
@@ -34,6 +34,10 @@ module ForemanWreckingball
     end
 
     def to_global(_options = {})
+      OperatingsystemStatus.to_global(status)
+    end
+
+    def self.to_global(status)
       case status
       when MISMATCH
         HostStatus::Global::WARN

--- a/app/models/foreman_wreckingball/spectre_v2_status.rb
+++ b/app/models/foreman_wreckingball/spectre_v2_status.rb
@@ -26,7 +26,7 @@ module ForemanWreckingball
     end
 
     def to_global(_options = {})
-      SpectreV2Status.to_global(status)
+      self.class.to_global(status)
     end
 
     def self.to_global(status)

--- a/app/models/foreman_wreckingball/spectre_v2_status.rb
+++ b/app/models/foreman_wreckingball/spectre_v2_status.rb
@@ -26,6 +26,10 @@ module ForemanWreckingball
     end
 
     def to_global(_options = {})
+      SpectreV2Status.to_global(status)
+    end
+
+    def self.to_global(status)
       case status
       when MISSING
         HostStatus::Global::ERROR

--- a/app/models/foreman_wreckingball/tools_status.rb
+++ b/app/models/foreman_wreckingball/tools_status.rb
@@ -26,7 +26,7 @@ module ForemanWreckingball
     end
 
     def to_global(_options = {})
-      ToolsStatus.to_global(status)
+      self.class.to_global(status)
     end
 
     def self.to_global(status)

--- a/app/models/foreman_wreckingball/tools_status.rb
+++ b/app/models/foreman_wreckingball/tools_status.rb
@@ -26,6 +26,10 @@ module ForemanWreckingball
     end
 
     def to_global(_options = {})
+      ToolsStatus.to_global(status)
+    end
+
+    def self.to_global(status)
       case status
       when VmwareFacet.tools_states[:toolsOk], POWERDOWN
         HostStatus::Global::OK

--- a/test/factories/foreman_wreckingball_factories.rb
+++ b/test/factories/foreman_wreckingball_factories.rb
@@ -151,6 +151,20 @@ FactoryBot.define do
     after(:build) { |status| status.status = status.to_status }
   end
 
+  factory :vmware_spectre_v2_status, class: 'ForemanWreckingball::SpectreV2Status' do
+    association :host, factory: [:host, :with_vmware_facet]
+    reported_at { Time.now.utc }
+    after(:build) { |status| status.status = status.to_status }
+
+    trait(:with_enabled) do
+      after(:build) { |status| status.status = ForemanWreckingball::SpectreV2Status::ENABLED }
+    end
+
+    trait(:with_missing) do
+      after(:build) { |status| status.status = ForemanWreckingball::SpectreV2Status::MISSING }
+    end
+  end
+
   factory :vmware_hardware_version_status, class: 'ForemanWreckingball::HardwareVersionStatus' do
     association :host, factory: [:host, :with_vmware_facet]
     reported_at { Time.now.utc }

--- a/test/factories/host.rb
+++ b/test/factories/host.rb
@@ -38,10 +38,18 @@ FactoryBot.modify do
       end
     end
 
+    trait :with_vmware_spectrev2_status do
+      with_vmware_facet
+      after(:create) do |host, _evaluator|
+        create :vmware_spectre_v2_status, host: host
+      end
+    end
+
     trait :with_wreckingball_statuses do
       with_vmware_tools_status
       with_vmware_operatingsystem_status
       with_vmware_cpu_hot_add_status
+      with_vmware_spectrev2_status
       with_vmware_hardware_version_status
     end
   end

--- a/test/integration/hosts_status_dashboard_test.rb
+++ b/test/integration/hosts_status_dashboard_test.rb
@@ -1,0 +1,50 @@
+require 'benchmark'
+
+require 'integration_test_plugin_helper'
+
+class HostsStatusDashboardTest < ActionDispatch::IntegrationTest
+  setup do
+    Setting::Wreckingball.load_defaults
+  end
+
+  test 'shows different vmware host statuses' do
+    # A few unassociated hosts
+    FactoryBot.create_list(:host, 10)
+    FactoryBot.create_list(:vmware_tools_status, 1)
+    FactoryBot.create_list(:vmware_operatingsystem_status, 2)
+    FactoryBot.create_list(:vmware_cpu_hot_add_status, 3)
+    FactoryBot.create_list(:vmware_spectre_v2_status, 4, :with_enabled)
+    FactoryBot.create_list(:vmware_spectre_v2_status, 5, :with_missing)
+    FactoryBot.create_list(:vmware_hardware_version_status, 6, :with_ok_status)
+    FactoryBot.create_list(:vmware_hardware_version_status, 7, :with_out_of_date_status)
+
+    visit status_dashboard_hosts_path
+
+    lists = find_all("div.list-view-pf-main-info")
+
+    # VMWare Tools
+    assert_content lists[0].text, "1 OK"
+    assert_content lists[0].text, "0 Warning"
+    assert_content lists[0].text, "0 Critical"
+
+    # VMWare Operating System
+    assert_content lists[1].text, "2 OK"
+    assert_content lists[1].text, "0 Warning"
+    assert_content lists[1].text, "0 Critical"
+
+    # VMWare CPU Hot Plug
+    assert_content lists[2].text, "3 OK"
+    assert_content lists[2].text, "0 Warning"
+    assert_content lists[2].text, "0 Critical"
+
+    # VMWare Spectre V2
+    assert_content lists[3].text, "4 OK"
+    assert_content lists[3].text, "0 Warning"
+    assert_content lists[3].text, "5 Critical"
+
+    # VMWare Hardware Version
+    assert_content lists[4].text, "6 OK"
+    assert_content lists[4].text, "7 Warning"
+    assert_content lists[4].text, "0 Critical"
+  end
+end

--- a/test/integration_test_plugin_helper.rb
+++ b/test/integration_test_plugin_helper.rb
@@ -1,0 +1,9 @@
+require 'integration_test_helper'
+
+require 'webmock/minitest'
+require 'webmock'
+require 'pry'
+
+# Add plugin to FactoryBot's paths
+FactoryBot.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
+FactoryBot.reload


### PR DESCRIPTION
This PR refactors the status query, which calculates a list of hosts for different statuses.

Instead of fetching all records from the database to calculate the status counts in Ruby, the updated query calculates them in the SQL query. One aspect to support the query was to add `*Status#to_global` methods as class methods in order to split the logic from the (loaded) record.

* add integration test + setup to check the query provides the right output
* set up integration tests
* add `vmware_spectre_v2_status` factory