### PR TITLE
Refactor Ajax query in status dashboard

### DIFF
--- a/app/controllers/foreman_wreckingball/hosts_controller.rb
+++ b/app/controllers/foreman_wreckingball/hosts_controller.rb
@@ -54,13 +54,12 @@ module ForemanWreckingball
     def status_hosts
       @status = STATUSES_MAP[params.fetch(:status).to_sym]
 
-      query = Host.authorized(:view_hosts, Host)
-                  .joins(@status.host_association)
-                  .includes(@status.host_association, :vmware_facet, :environment)
-
-      all_hosts = query.where.not('host_status.status': @status.global_ok_list)
-                       .preload(:owner)
-                       .order(:name)
+      all_hosts = Host.authorized(:view_hosts, Host)
+                      .joins(@status.host_association)
+                      .includes(@status.host_association, :vmware_facet, :environment)
+                      .where.not('host_status.status': @status.global_ok_list)
+                      .preload(:owner)
+                      .order(:name)
 
       @count = all_hosts.size
       @hosts = all_hosts.paginate(page: params.fetch(:page, 1), per_page: params.fetch(:per_page, 100))

--- a/app/controllers/foreman_wreckingball/hosts_controller.rb
+++ b/app/controllers/foreman_wreckingball/hosts_controller.rb
@@ -58,7 +58,7 @@ module ForemanWreckingball
                   .joins(@status.host_association)
                   .includes(@status.host_association, :vmware_facet, :environment)
 
-      all_hosts = query.where('"host_status"."status" NOT IN (:status)', status: @status.global_ok_list)
+      all_hosts = query.where.not('host_status.status': @status.global_ok_list)
                        .preload(:owner)
                        .order(:name)
 

--- a/app/controllers/foreman_wreckingball/hosts_controller.rb
+++ b/app/controllers/foreman_wreckingball/hosts_controller.rb
@@ -24,16 +24,8 @@ module ForemanWreckingball
     }.freeze
 
     def status_dashboard
-      statuses = [
-        ToolsStatus,
-        OperatingsystemStatus,
-        CpuHotAddStatus,
-        SpectreV2Status,
-        HardwareVersionStatus
-      ]
-
       @newest_data = Host.authorized(:view_hosts, Host).joins(:vmware_facet).maximum('vmware_facets.updated_at')
-      @data = statuses.map do |status|
+      @data = STATUSES_MAP.map do |_key, status|
         host_association = status.host_association
 
         # Let the database calculate status counts, then map to HostStatus::Global values

--- a/app/controllers/foreman_wreckingball/hosts_controller.rb
+++ b/app/controllers/foreman_wreckingball/hosts_controller.rb
@@ -54,19 +54,15 @@ module ForemanWreckingball
     def status_hosts
       @status = STATUSES_MAP[params.fetch(:status).to_sym]
 
-      total = Host.authorized(:view_hosts, Host)
+      query = Host.authorized(:view_hosts, Host)
                   .joins(@status.host_association)
                   .includes(@status.host_association, :vmware_facet, :environment)
-                  .count
 
-      all_hosts = Host.authorized(:view_hosts, Host)
-                      .joins(@status.host_association)
-                      .includes(@status.host_association, :vmware_facet, :environment)
-                      .where('"host_status"."status" NOT IN (:status)', status: @status.global_ok_list)
-                      .preload(:owner)
-                      .order(:name)
+      all_hosts = query.where('"host_status"."status" NOT IN (:status)', status: @status.global_ok_list)
+                       .preload(:owner)
+                       .order(:name)
 
-      @count = total
+      @count = all_hosts.size
       @hosts = all_hosts.paginate(page: params.fetch(:page, 1), per_page: params.fetch(:per_page, 100))
 
       respond_to do |format|

--- a/app/models/foreman_wreckingball/cpu_hot_add_status.rb
+++ b/app/models/foreman_wreckingball/cpu_hot_add_status.rb
@@ -38,6 +38,10 @@ module ForemanWreckingball
       end
     end
 
+    def self.global_ok_list()
+      [OK]
+    end
+
     def to_label(_options = {})
       case status
       when PERFORMANCE_DEGRATION

--- a/app/models/foreman_wreckingball/cpu_hot_add_status.rb
+++ b/app/models/foreman_wreckingball/cpu_hot_add_status.rb
@@ -38,7 +38,7 @@ module ForemanWreckingball
       end
     end
 
-    def self.global_ok_list()
+    def self.global_ok_list
       [OK]
     end
 

--- a/app/models/foreman_wreckingball/hardware_version_status.rb
+++ b/app/models/foreman_wreckingball/hardware_version_status.rb
@@ -46,7 +46,7 @@ module ForemanWreckingball
       end
     end
 
-    def self.global_ok_list()
+    def self.global_ok_list
       [OK]
     end
 

--- a/app/models/foreman_wreckingball/hardware_version_status.rb
+++ b/app/models/foreman_wreckingball/hardware_version_status.rb
@@ -46,6 +46,10 @@ module ForemanWreckingball
       end
     end
 
+    def self.global_ok_list()
+      [OK]
+    end
+
     def to_label(_options = {})
       case status
       when OUTOFDATE

--- a/app/models/foreman_wreckingball/operatingsystem_status.rb
+++ b/app/models/foreman_wreckingball/operatingsystem_status.rb
@@ -46,7 +46,7 @@ module ForemanWreckingball
       end
     end
 
-    def self.global_ok_list()
+    def self.global_ok_list
       [OK]
     end
 

--- a/app/models/foreman_wreckingball/operatingsystem_status.rb
+++ b/app/models/foreman_wreckingball/operatingsystem_status.rb
@@ -46,6 +46,10 @@ module ForemanWreckingball
       end
     end
 
+    def self.global_ok_list()
+      [OK]
+    end
+
     def to_label(_options = {})
       case status
       when MISMATCH

--- a/app/models/foreman_wreckingball/spectre_v2_status.rb
+++ b/app/models/foreman_wreckingball/spectre_v2_status.rb
@@ -38,6 +38,10 @@ module ForemanWreckingball
       end
     end
 
+    def self.global_ok_list()
+      [ENABLED]
+    end
+
     def to_label(_options = {})
       case status
       when MISSING

--- a/app/models/foreman_wreckingball/spectre_v2_status.rb
+++ b/app/models/foreman_wreckingball/spectre_v2_status.rb
@@ -38,7 +38,7 @@ module ForemanWreckingball
       end
     end
 
-    def self.global_ok_list()
+    def self.global_ok_list
       [ENABLED]
     end
 

--- a/app/models/foreman_wreckingball/tools_status.rb
+++ b/app/models/foreman_wreckingball/tools_status.rb
@@ -40,7 +40,7 @@ module ForemanWreckingball
       end
     end
 
-    def self.global_ok_list()
+    def self.global_ok_list
       [VmwareFacet.tools_states[:toolsOk], POWERDOWN]
     end
 

--- a/app/models/foreman_wreckingball/tools_status.rb
+++ b/app/models/foreman_wreckingball/tools_status.rb
@@ -40,6 +40,10 @@ module ForemanWreckingball
       end
     end
 
+    def self.global_ok_list()
+      [VmwareFacet.tools_states[:toolsOk], POWERDOWN]
+    end
+
     def to_label(_options = {})
       return N_('Powered down') if status == POWERDOWN
       host.vmware_facet.tools_state_label

--- a/app/views/foreman_wreckingball/hosts/status_hosts.json.rabl
+++ b/app/views/foreman_wreckingball/hosts/status_hosts.json.rabl
@@ -3,7 +3,7 @@
 object false
 
 node(:recordsTotal) { @count }
-node(:recordsFiltered) { @count }
+node(:recordsFiltered) { @count - @hosts.size }
 node(:data) do
   partial 'foreman_wreckingball/hosts/_hosts', object: @hosts,
                                                locals: {

--- a/app/views/foreman_wreckingball/hosts/status_hosts.json.rabl
+++ b/app/views/foreman_wreckingball/hosts/status_hosts.json.rabl
@@ -3,7 +3,7 @@
 object false
 
 node(:recordsTotal) { @count }
-node(:recordsFiltered) { @count - @hosts.size }
+node(:recordsFiltered) { @count }
 node(:data) do
   partial 'foreman_wreckingball/hosts/_hosts', object: @hosts,
                                                locals: {

--- a/test/controllers/foreman_wreckingball/hosts_controller_test.rb
+++ b/test/controllers/foreman_wreckingball/hosts_controller_test.rb
@@ -51,19 +51,21 @@ module ForemanWreckingball
                            session: set_session_user, xhr: true
 
         assert_response :ok
-        hosts_names = JSON.parse(response.body)['data'].map { |host| host['name'] }
+
+        data = JSON.parse(response.body)['data']
+
+        hosts_names = data.map { |host| host['name'] }
+        assert_equal 1, data.size
         assert_includes hosts_names, out_of_date_status.host.name
         refute_includes hosts_names, ok_status.host.name
       end
 
       test 'returns hosts for spectre v2 status' do
         FactoryBot.create_list(:vmware_spectre_v2_status, 1, :with_enabled)
-        missing_list = FactoryBot.create_list(:vmware_spectre_v2_status, 2, :with_missing)
+        FactoryBot.create_list(:vmware_spectre_v2_status, 2, :with_missing)
 
         get :status_hosts, params: { status: ::ForemanWreckingball::SpectreV2Status.host_association },
                            session: set_session_user, xhr: true
-
-        hosts = missing_list.map(&:host)
 
         data = JSON.parse(response.body)['data']
         assert_equal 2, data.size

--- a/test/controllers/foreman_wreckingball/hosts_controller_test.rb
+++ b/test/controllers/foreman_wreckingball/hosts_controller_test.rb
@@ -38,8 +38,8 @@ module ForemanWreckingball
 
         assert_response :ok
         json = JSON.parse(response.body)
-        assert_equal 7, json['recordsTotal']
-        assert_equal 3, json['recordsFiltered']
+        assert_equal 4, json['recordsTotal']
+        assert_equal 4, json['recordsFiltered']
         assert_equal 4, json['data'].size
       end
 

--- a/test/controllers/foreman_wreckingball/hosts_controller_test.rb
+++ b/test/controllers/foreman_wreckingball/hosts_controller_test.rb
@@ -55,6 +55,19 @@ module ForemanWreckingball
         assert_includes hosts_names, out_of_date_status.host.name
         refute_includes hosts_names, ok_status.host.name
       end
+
+      test 'returns hosts for spectre v2 status' do
+        FactoryBot.create_list(:vmware_spectre_v2_status, 1, :with_enabled)
+        missing_list = FactoryBot.create_list(:vmware_spectre_v2_status, 2, :with_missing)
+
+        get :status_hosts, params: { status: ::ForemanWreckingball::SpectreV2Status.host_association },
+                           session: set_session_user, xhr: true
+
+        hosts = missing_list.map(&:host)
+
+        data = JSON.parse(response.body)['data']
+        assert_equal 2, data.size
+      end
     end
 
     describe '#refresh_status_dashboard' do

--- a/test/controllers/foreman_wreckingball/hosts_controller_test.rb
+++ b/test/controllers/foreman_wreckingball/hosts_controller_test.rb
@@ -29,6 +29,20 @@ module ForemanWreckingball
     end
 
     describe '#status_hosts' do
+      test 'returns correct counts' do
+        FactoryBot.create_list(:vmware_hardware_version_status, 3, :with_ok_status)
+        FactoryBot.create_list(:vmware_hardware_version_status, 4, :with_out_of_date_status)
+
+        get :status_hosts, params: { status: ::ForemanWreckingball::HardwareVersionStatus.host_association },
+                           session: set_session_user, xhr: true
+
+        assert_response :ok
+        json = JSON.parse(response.body)
+        assert_equal 7, json['recordsTotal']
+        assert_equal 3, json['recordsFiltered']
+        assert_equal 4, json['data'].size
+      end
+
       test 'returns hosts for status' do
         ok_status = FactoryBot.create(:vmware_hardware_version_status, :with_ok_status)
         out_of_date_status = FactoryBot.create(:vmware_hardware_version_status, :with_out_of_date_status)


### PR DESCRIPTION
Refactor the controller action that is called via Ajax. It filters the hosts in the SQL query, instead of loading all models to filter them on the Ruby side. 

* refactor Ajax query to fetch unhealthy hosts for a specific status
* add functions to `*Status` classes to be able to filter hosts in SQL query
* fix count of filtered hosts in JSON

My recommendation is to come back to this change set when starting on #50. My impression is the mapping functions `*Status.to_global` and `*Status.global_ok_list` become obsolete once the global status is stored in the database. It should also makes things a bit easier.