### PR TITLE
fix ajax permissions for non-admin users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
   - cd ../foreman
   - bundle exec rake test:${FOREMAN_PLUGIN_NAME}
   - bundle exec rake "plugin:assets:precompile[${FOREMAN_PLUGIN_NAME}]" RAILS_ENV=production
+  - bundle exec rake test TEST="test/unit/foreman/access_permissions_test.rb"
 env:
   global:
     - TESTOPTS=-v

--- a/app/controllers/foreman_wreckingball/hosts_controller.rb
+++ b/app/controllers/foreman_wreckingball/hosts_controller.rb
@@ -122,7 +122,7 @@ module ForemanWreckingball
 
     def action_permission
       case params[:action]
-      when 'status_dashboard'
+      when 'status_dashboard', 'status_hosts'
         'view'
       when 'refresh_status_dashboard'
         'refresh_vmware_status'

--- a/lib/foreman_wreckingball/engine.rb
+++ b/lib/foreman_wreckingball/engine.rb
@@ -47,7 +47,8 @@ module ForemanWreckingball
 
         # Extend built in permissions
         Foreman::AccessControl.permission(:view_hosts).actions.concat [
-          'foreman_wreckingball/hosts/status_dashboard'
+          'foreman_wreckingball/hosts/status_dashboard',
+          'foreman_wreckingball/hosts/status_hosts'
         ]
 
         menu :top_menu, :wreckingball_status_dashboard, :url_hash => { :controller => :'foreman_wreckingball/hosts', :action => :status_dashboard },


### PR DESCRIPTION
This fixes access permissions for non-admin users on the ajax endpoint to load the host list.

@kamils-iRonin: Can you please review?