### PR TITLE
Start remediate action for hosts via bulk action

### DIFF
--- a/app/assets/javascripts/foreman_wreckingball/status_hosts_table.js
+++ b/app/assets/javascripts/foreman_wreckingball/status_hosts_table.js
@@ -10,7 +10,8 @@ $(document).ready(() => {
         processing: true,
         serverSide: true,
         columnDefs: [
-          { className: 'ellipsis', targets: [0, 1, 2, 3] }
+          { className: 'ellipsis', targets: [1, 2, 3, 4] },
+          { width: '10px', targets: 0 }
         ],
         ajax: {
           url: $(element).data('hosts-url'),
@@ -26,13 +27,23 @@ $(document).ready(() => {
           dataSrc: (json) => {
             return json.data.map((e) => {
               let row = [
+                `<input name='status-id' type='checkbox' value='${e.status.id}' data-remediate='${!!e.remediate}' >`,
                 `<a href="${e.path}">${e.name}</a>`,
                 `<span class="${e.status.icon_class}"></span><span class="${e.status.status_class}">${e.status.label}</span>`,
                 (e.owner || {}).name || '',
                 (e.environment || {}).name || ''
               ];
               if(e.remediate) {
-                row.push(`<span class="btn btn-sm btn-default"><a data-title="${e.remediate.title}" data-submit-class="btn-danger" onclick="show_modal(this); return false;" data-id="aid_wreckingball_hosts_${e.name}_schedule_remediate" href="${e.remediate.path}">${e.remediate.label}</a></span>`);
+                row.push(`
+                  <span class="btn btn-sm btn-default">
+                    <a data-title="${e.remediate.title}"
+                       data-id="aid_wreckingball_hosts_${e.name}_schedule_remediate"
+                       data-status-id="${e.status.id}"
+                       onclick="show_modal(this); return false;"
+                       href="${e.remediate.path}">
+                         ${e.remediate.label}
+                    </a>
+                  </span>`);
               } else {
                 row.push(null);
               }
@@ -43,6 +54,27 @@ $(document).ready(() => {
       });
       $(element).on('error.dt', (_, settings) => {
         $(settings.nTable).closest('.status-hosts-container').addClass('ajax-error');
+      });
+      $(element).on('page.dt', () => {
+        $selectAll.prop('checked', false).change();
+        $remediateSelected.attr('disabled', true);
+      });
+
+      const $selectAll = $(this).find(':checkbox[name="select-all"]');
+      const $remediateSelected = $(this).find('a.remediate-selected');
+
+      $selectAll.prop('checked', false);
+
+      $selectAll.change(() => {
+        const $selectHost = $(this).find(':checkbox[name="status-id"]');
+        $selectHost.prop('checked', $selectAll.is(':checked'));
+        $remediateSelected.attr('disabled', !$selectAll.is(':checked'));
+      });
+
+      $(this).on('change', ':checkbox[name=status-id]', () => {
+        const isAnyHostChecked = $(this).find(':checkbox[name="status-id"]').is(':checked');
+        $selectAll.prop('checked', isAnyHostChecked);
+        $remediateSelected.attr('disabled', !isAnyHostChecked);
       });
     });
   });

--- a/app/helpers/foreman_wreckingball/statuses_helper.rb
+++ b/app/helpers/foreman_wreckingball/statuses_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ForemanWreckingball
+  module StatusesHelper
+    def status_actions(host_association, owned_only, supports_remediate)
+      actions = []
+      actions << display_link_if_authorized(_('Refresh'),
+                                            hash_for_refresh_status_dashboard_hosts_path,
+                                            title: _('Refresh Data'),
+                                            method: :put)
+      if supports_remediate
+        actions << display_link_if_authorized(_('Remediate All'),
+                                              hash_for_schedule_remediate_hosts_path,
+                                              'data-host-association': host_association,
+                                              'data-owned-only': owned_only,
+                                              onClick: 'show_modal(this); return false;')
+      end
+      actions.reject(&:blank?)
+    end
+  end
+end

--- a/app/lib/actions/foreman_wreckingball/bulk_remediate.rb
+++ b/app/lib/actions/foreman_wreckingball/bulk_remediate.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Actions
+  module ForemanWreckingball
+    class BulkRemediate < Actions::Base
+      def plan(statuses)
+        sequence do
+          statuses.group_by(&:class).each do |statuses_klass, statuses_list|
+            plan_action(::Actions::BulkAction, statuses_klass.remediate_action, statuses_list.map(&:host)) if statuses_klass.respond_to?(:remediate_action)
+          end
+        end
+      end
+
+      def run
+        # dummy run phase to save input
+      end
+
+      def resource_locks
+        :link
+      end
+
+      def humanized_name
+        _('Bulk remediate')
+      end
+    end
+  end
+end

--- a/app/models/concerns/foreman_wreckingball/host_status_extensions.rb
+++ b/app/models/concerns/foreman_wreckingball/host_status_extensions.rb
@@ -7,7 +7,7 @@ module ForemanWreckingball
     end
 
     def find_wreckingball_status_by_host_association(host_association)
-      wreckingball_statuses.find { |s| s.host_association == host_association }
+      wreckingball_statuses.find { |s| s.host_association.to_s == host_association.to_s }
     end
   end
 end

--- a/app/views/foreman_wreckingball/hosts/_status_dashboard_content.erb
+++ b/app/views/foreman_wreckingball/hosts/_status_dashboard_content.erb
@@ -24,6 +24,8 @@
     counter: status[:counter],
     status: status[:host_association],
     supports_remediate: status[:supports_remediate],
+    host_association: status[:host_association],
+    owned_only: params[:owned_only],
     id: idx
   }
 %>

--- a/app/views/foreman_wreckingball/hosts/_status_row.html.erb
+++ b/app/views/foreman_wreckingball/hosts/_status_row.html.erb
@@ -3,18 +3,14 @@
     <div class="list-view-pf-expand">
       <span class="fa fa-angle-right"></span>
     </div>
-    <div class="list-view-pf-actions">
-      <% if User.current.allowed_to?(hash_for_refresh_status_dashboard_hosts_path) %>
-        <div class="dropdown pull-right dropdown-kebab-pf">
-          <button class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight<%= id %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-            <span class="fa fa-ellipsis-v"></span>
-          </button>
-          <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight<%= id %>">
-            <li><%= display_link_if_authorized(_('Refresh'), hash_for_refresh_status_dashboard_hosts_path, :title => _('Refresh data'), :method => :put) %></li>
-          </ul>
-        </div>
-      <% end %>
-    </div>
+    <%=
+      render :partial => 'status_row_actions', locals: {
+        id: id,
+        supports_remediate: supports_remediate,
+        host_association: host_association,
+        owned_only: owned_only
+      }
+    %>
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
         <span class="pficon list-view-pf-icon-md <%= classes_for_vmware_status_row(counter) %>"></span>

--- a/app/views/foreman_wreckingball/hosts/_status_row_actions.html.erb
+++ b/app/views/foreman_wreckingball/hosts/_status_row_actions.html.erb
@@ -1,0 +1,22 @@
+<% actions = status_actions(host_association, owned_only, supports_remediate) %>
+
+<% if actions.any? %>
+  <div class='list-view-pf-actions'>
+    <div class='dropdown pull-right dropdown-kebab-pf'>
+      <%= content_tag :button, class: 'btn btn-link dropdown-toggle',
+                               type: 'button',
+                               id: "dropdownKebabRight#{id}",
+                               'data-toggle': 'dropdown',
+                               'aria-haspopup': true,
+                               'aria-expanded': true do %>
+        <span class='fa fa-ellipsis-v' />
+      <% end %>
+
+      <%= content_tag :ul, class: 'dropdown-menu dropdown-menu-right', 'aria-labelledby': "dropdownKebabRight#{id}" do %>
+        <% actions.each do |action| %>
+          <%= content_tag :li, action %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/foreman_wreckingball/hosts/_status_row_hosts_table.html.erb
+++ b/app/views/foreman_wreckingball/hosts/_status_row_hosts_table.html.erb
@@ -1,8 +1,13 @@
+<%= render :partial => 'status_row_hosts_table_actions', locals: { supports_remediate: supports_remediate } %>
+
 <%= content_tag :table, id: status,
                         class: 'table table-striped table-fixed status-hosts',
                         'data-hosts-url': ajax_status_dashboard_hosts_path(status, owned_only: params[:owned_only]) do %>
   <%= content_tag :thead do %>
     <%= content_tag :tr do %>
+      <%= content_tag :th do %>
+        <%= check_box_tag 'select-all' %>
+      <% end %>
       <%= content_tag :th, _('Hostname') %>
       <%= content_tag :th, _('Status') %>
       <%= content_tag :th, _('Owner') %>
@@ -12,6 +17,8 @@
   <% end %>
   <%= content_tag(:tbody) {} %>
 <% end %>
+
+<%= render :partial => 'status_row_hosts_table_actions', locals: { supports_remediate: supports_remediate } %>
 
 <%= alert header: _("Oops, we're sorry but something went wrong"), text: '',
           class: 'alert-danger', close: false %>

--- a/app/views/foreman_wreckingball/hosts/_status_row_hosts_table_actions.html.erb
+++ b/app/views/foreman_wreckingball/hosts/_status_row_hosts_table_actions.html.erb
@@ -1,0 +1,9 @@
+<%= content_tag :div, class: 'text-right' do %>
+  <% if supports_remediate %>
+    <%= content_tag :a, _('Remediate selected'),
+                        href: schedule_remediate_hosts_path,
+                        class: 'btn btn-default remediate-selected',
+                        onclick: 'show_modal(this); return false;',
+                        disabled: true %>
+  <% end %>
+<% end %>

--- a/app/views/foreman_wreckingball/hosts/schedule_remediate.html.erb
+++ b/app/views/foreman_wreckingball/hosts/schedule_remediate.html.erb
@@ -1,35 +1,53 @@
-<% title _('Remediate %s') % @host %>
+<% title _('Remediate') %>
 <% javascript 'foreman_tasks/trigger_form' %>
 <% stylesheet 'foreman_tasks/trigger_form' %>
 
-
-<% if @status.class.respond_to?(:dangerous_remediate?) && @status.class.dangerous_remediate? -%>
-<%= alert(:text => _('This will cause a service interruption.'), :class => 'alert-warning', :close => false) %>
-<% end -%>
-
-<%= form_for @triggering, :url => submit_remediate_host_path(:id => @host.id, :status_id => @status), :html => { :class => 'form-horizontal', :id => 'schedule_remediate_form' } do |f| %>
-  <%= javascript_tag do %>
-    $(function() { trigger_form_selector_binds('<%= f.options[:html][:id] %>','<%= f.object_name %>') });
+<% if @statuses.any? %>
+  <% if @statuses.group_by(&:class).map { |i| i.first}.select { |i| i.try(:dangerous_remediate?) }.any? %>
+    <%= alert(:text => _('This will cause a service interruption.'), :class => 'alert-warning', :close => false) %>
   <% end %>
-  <div class="form-group">
-    <label class="col-md-2 control-label"><%= _('Schedule') %></label>
-    <div class="col-md-8">
-      <%= fields_for :triggering, @triggering do |trigger_fields| %>
-        <%= radio_button_f trigger_fields, :mode, :class => 'trigger_mode_selector', :value => 'immediate', :text => _("Execute now") %>
-        <%= radio_button_f trigger_fields, :mode, :class => 'trigger_mode_selector', :value => 'future',    :text => _("Schedule future execution") %>
+
+  <%= n_('One host selected for remediation.', '%s hosts selected for remediation.', @statuses.count) % @statuses.count %>
+
+  <ul class='hosts-list' style='max-height: 100px; overflow-y: scroll;'>
+    <% @statuses.each do |status| %>
+      <li>
+        <%= status.host.name %>
+        <%= content_tag(:span, nil, class: 'glyphicon glyphicon-warning-sign text-warning', title: _('This will cause a service interruption.')) if status.class.try(:dangerous_remediate?) %>
+      </li>
+    <% end %>
+  </ul>
+
+  <%= form_for @triggering, html: { class: 'form-horizontal', id: 'schedule_remediate_form' },
+                            url: submit_remediate_hosts_path(host_association: @statuses_params[:host_association],
+                                                             owned_only: @statuses_params[:owned_only],
+                                                             status_ids: @statuses_params[:status_ids]) do |f| %>
+    <%= javascript_tag do %>
+      $(function() { trigger_form_selector_binds('<%= f.options[:html][:id] %>','<%= f.object_name %>') });
+    <% end %>
+    <div class="form-group">
+      <label class="col-md-2 control-label"><%= _('Schedule') %></label>
+      <div class="col-md-8">
+        <%= fields_for :triggering, @triggering do |trigger_fields| %>
+          <%= radio_button_f trigger_fields, :mode, :class => 'trigger_mode_selector', :value => 'immediate', :text => _('Execute now') %>
+          <%= radio_button_f trigger_fields, :mode, :class => 'trigger_mode_selector', :value => 'future',    :text => _('Schedule future execution') %>
+      </div>
     </div>
-  </div>
 
-  <div class="trigger_fields">
-    <%= content_tag(:fieldset, nil, :id => 'trigger_mode_future', :class => "trigger_mode_form #{'hidden' unless @triggering.future?}") do
-      safe_join([
-        text_f(f, :start_at_raw, :label => _('Start at'), :placeholder => 'YYYY-mm-dd HH:MM'),
-        text_f(f, :start_before_raw, :label => _('Start before'), :placeholder => 'YYYY-mm-dd HH:MM',
-                                     :label_help => _('Indicates that the action should be cancelled if it cannot be started before this time.'))
-      ])
-    end %>
-  </div>
+    <div class="trigger_fields">
+      <%= content_tag(:fieldset, nil, id: 'trigger_mode_future', class: "trigger_mode_form #{'hidden' unless @triggering.future?}") do
+        safe_join([
+          text_f(f, :start_at_raw, label: _('Start at'), placeholder: 'YYYY-mm-dd HH:MM'),
+          text_f(f, :start_before_raw, label: _('Start before'), placeholder: 'YYYY-mm-dd HH:MM',
+                                       label_help: _('Indicates that the action should be cancelled if it cannot be started before this time.'))
+        ])
+      end %>
+    </div>
+    <% end %>
+
+    <%= submit_or_cancel f, false, :cancel_path => { controller: :'foreman_wreckingball/hosts', action: :status_dashboard } %>
   <% end %>
-
-  <%= submit_or_cancel f, false, :cancel_path => { :controller => :'foreman_wreckingball/hosts', :action => :status_dashboard } %>
+<% else %>
+  <%= content_tag :h3, _('No hosts selected') %>
+  <%= content_tag :p, _('Please select some hosts and try again') %>
 <% end %>

--- a/app/views/foreman_wreckingball/hosts/status_dashboard.html.erb
+++ b/app/views/foreman_wreckingball/hosts/status_dashboard.html.erb
@@ -13,11 +13,11 @@
     render 'status_dashboard_empty'
   end
 %>
-<%= render :partial => 'common/modal', :locals => {
-  :id => 'confirmation-modal',
-  :title => _('Please Confirm'),
-  :buttons => [
-    button_tag(_('Cancel'), :class => 'btn btn-default', :data => { :dismiss => 'modal' }, :type => 'button'),
-    button_tag(_('Submit'), :class => 'btn btn-primary', :data => { :action => 'submit' }, :onclick => 'submit_modal_form()')
+<%= render partial: 'common/modal', locals: {
+  id: 'confirmation-modal',
+  title: _('Please Confirm'),
+  buttons: [
+    button_tag(_('Cancel'), class: 'btn btn-default', data: { dismiss: 'modal' }, type: 'button'),
+    button_tag(_('Submit'), class: 'btn btn-primary', data: { action: 'submit' }, onclick: 'submit_modal_form()')
   ]
 } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,15 +4,13 @@ Rails.application.routes.draw do
   scope '/wreckingball' do
     constraints(:id => /[^\/]+/) do
       resources :hosts, controller: 'foreman_wreckingball/hosts', only: [] do
-        member do
-          get :schedule_remediate
-          post :submit_remediate
-        end
         collection do
           get :status_dashboard
           get :status_managed_hosts_dashboard
           get 'status_dashboard/hosts(/:status)', as: :ajax_status_dashboard, action: :status_hosts, defaults: { format: :json }
           put :refresh_status_dashboard
+          get :schedule_remediate
+          post :submit_remediate
         end
       end
     end

--- a/test/actions/foreman_wreckingball/bulk_remediate_test.rb
+++ b/test/actions/foreman_wreckingball/bulk_remediate_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+module Actions
+  module ForemanWreckingball
+    describe Actions::ForemanWreckingball::BulkRemediate do
+      include Dynflow::Testing
+
+      let(:action_class) { ::Actions::ForemanWreckingball::BulkRemediate }
+      let(:bulk_action) { ::Actions::BulkAction }
+      let(:action) { create_action(action_class) }
+
+      setup do
+        Setting::Wreckingball.load_defaults
+        FactoryBot.create_list(:host, 2, :managed, :with_wreckingball_statuses)
+      end
+
+      it 'plans remediate action' do
+        ::ForemanWreckingball::Engine::WRECKINGBALL_STATUSES.map(&:constantize)
+                                                            .select(&:supports_remediate?)
+                                                            .each do |status|
+          statuses = HostStatus::Status.where(type: status.to_s)
+          plan_action(action, statuses)
+
+          assert_action_planed_with(action, bulk_action, status.remediate_action, statuses.map(&:host))
+        end
+      end
+    end
+  end
+end

--- a/test/helpers/foreman_wreckingball/status_helper.rb
+++ b/test/helpers/foreman_wreckingball/status_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module ForemanWreckingball
+  module StatusHelper
+    def assert_statuses(expected)
+      actual = request.env['action_controller.instance'].instance_variable_get('@statuses')
+      assert_equal expected, actual
+    end
+  end
+end

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -5,6 +5,8 @@ require 'test_helper'
 require 'database_cleaner'
 require 'dynflow/testing'
 
+Dir["#{__dir__}/helpers/foreman_wreckingball/**.rb"].each { |f| require f }
+
 # Add plugin to FactoryBot's paths
 FactoryBot.definition_file_paths << File.join(ForemanTasks::Engine.root, 'test', 'factories')
 FactoryBot.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')


### PR DESCRIPTION
closes #74

With "Remediate all" you can start remediate action for all non-ok statuses.
![image](https://user-images.githubusercontent.com/37402924/52040996-6f2b8f00-2539-11e9-860a-f8e7d5f5b03e.png)

You can also select the statuses for which you want to start remediate action.
![image](https://user-images.githubusercontent.com/37402924/52041053-91251180-2539-11e9-8c42-4b41616f0e01.png)
