### PR TITLE
Feature: Add status site to check managed host VMs

### DIFF
--- a/app/controllers/foreman_wreckingball/hosts_controller.rb
+++ b/app/controllers/foreman_wreckingball/hosts_controller.rb
@@ -44,19 +44,19 @@ module ForemanWreckingball
 
     def status_managed_hosts_dashboard
       @hosts = Host::Managed.authorized(:view_hosts, Host)
-                   .try { |query| params[:owned_only] ? query.owned_by_current_user_or_group_with_current_user : query }
+                            .try { |query| params[:owned_only] ? query.owned_by_current_user_or_group_with_current_user : query }
 
       compute_resources = ComputeResource.where(:type => 'Foreman::Model::Vmware')
 
       # get all vms by compute resource id
       vms_by_compute_resource_id = {}
       # NOTE The call to ComputeResource#vms may slow things down
-      compute_resources.each { |cr| vms_by_compute_resource_id[cr.id] = cr.vms }
+      compute_resources.each { |cr| vms_by_compute_resource_id[cr.id] = cr.vms(eager_loading: true) }
 
       vms_by_uuid = vms_by_compute_resource_id.values.flatten.group_by(&:uuid)
 
       # Find all hosts with duplicate VMs
-      @duplicate_vms = vms_by_uuid.select{ |_uuid, vms| vms.size > 1 }
+      @duplicate_vms = vms_by_uuid.select { |_uuid, vms| vms.size > 1 }
 
       @missing_hosts = []
       @different_hosts = []
@@ -65,9 +65,9 @@ module ForemanWreckingball
         next unless host.compute_resource_id
 
         # find the compute resource id of the host in the vm map
-        cr_id, _vms = vms_by_compute_resource_id.find{ |_cr_id, vms| vms.find{ |vm| vm.uuid == host.uuid } }
+        cr_id, _vms = vms_by_compute_resource_id.find { |_cr_id, vms| vms.find { |vm| vm.uuid == host.uuid } }
 
-        if cr_id == nil
+        if cr_id.nil?
           # No compute resource id is found, vSphere does not have the vm uuid
           @missing_hosts << host
         elsif cr_id != host.compute_resource_id

--- a/app/controllers/foreman_wreckingball/hosts_controller.rb
+++ b/app/controllers/foreman_wreckingball/hosts_controller.rb
@@ -50,9 +50,9 @@ module ForemanWreckingball
 
       # get all vms by compute resource id
       vms_by_compute_resource_id = {}
+      # NOTE The call to ComputeResource#vms may slow things down
       compute_resources.each { |cr| vms_by_compute_resource_id[cr.id] = cr.vms }
 
-      # NOTE The call to ComputeResource#vms may slow things down
       vms_by_uuid = vms_by_compute_resource_id.values.flatten.group_by(&:uuid)
 
       # Find all hosts with duplicate VMs

--- a/app/views/foreman_wreckingball/hosts/status_managed_hosts_dashboard.html.erb
+++ b/app/views/foreman_wreckingball/hosts/status_managed_hosts_dashboard.html.erb
@@ -1,0 +1,20 @@
+<% title _('VMware Managed Hosts Overview') %>
+<% javascript 'foreman_wreckingball/modal' %>
+<% javascript 'foreman_wreckingball/status_hosts_table' %>
+<% stylesheet 'foreman_wreckingball/status_hosts_table' %>
+
+<%= title_actions(
+  button_group(
+    if params[:owned_only]
+      link_to _('Show all hosts'), status_managed_hosts_dashboard_hosts_path, class: 'btn btn-default'
+    else
+      link_to _('Show only owned hosts'), status_managed_hosts_dashboard_hosts_path(owned_only: true), class: 'btn btn-default'
+    end
+  )
+) %>
+
+<div class="list-group list-view-pf list-view-pf-equalized-column" style="max-height: initial;">
+<% @missing_hosts.each do |host| %>
+  <div><%= host.name %></div>
+<% end %>
+</div>

--- a/app/views/foreman_wreckingball/hosts/status_managed_hosts_dashboard.html.erb
+++ b/app/views/foreman_wreckingball/hosts/status_managed_hosts_dashboard.html.erb
@@ -15,7 +15,7 @@
 
 <% if @missing_hosts.any? %>
   <div id="missing_vms">
-    <h2>List of missing hosts</h2>
+    <h2>List of hosts missing not found in vSphere</h2>
     <div class="list-group list-view-pf list-view-pf-equalized-column" style="max-height: initial;">
     <% @missing_hosts.each do |host| %>
       <div><%= host.name %></div>

--- a/app/views/foreman_wreckingball/hosts/status_managed_hosts_dashboard.html.erb
+++ b/app/views/foreman_wreckingball/hosts/status_managed_hosts_dashboard.html.erb
@@ -13,8 +13,37 @@
   )
 ) %>
 
-<div class="list-group list-view-pf list-view-pf-equalized-column" style="max-height: initial;">
-<% @missing_hosts.each do |host| %>
-  <div><%= host.name %></div>
+<% if @missing_hosts.any? %>
+  <div id="missing_vms">
+    <h2>List of missing hosts</h2>
+    <div class="list-group list-view-pf list-view-pf-equalized-column" style="max-height: initial;">
+    <% @missing_hosts.each do |host| %>
+      <div><%= host.name %></div>
+    <% end %>
+    </div>
+  </div>
 <% end %>
-</div>
+
+<% if @duplicate_vms.any? %>
+  <div id="duplicate_vms">
+    <h2>List of VMs with same uuid</h2>
+    <div class="list-group list-view-pf list-view-pf-equalized-column" style="max-height: initial;">
+    <% @duplicate_vms.each do |uuid, hosts| %>
+      <% hosts.each do |host| %>
+        <div><%= host.uuid %> - <%= host.name %></div>
+      <% end %>
+    <% end %>
+    </div>
+  </div>
+<% end %>
+
+<% if @different_hosts.any? %>
+  <div id="different_vms">
+    <h2>List of VMs associated with different compute resources</h2>
+    <div class="list-group list-view-pf list-view-pf-equalized-column" style="max-height: initial;">
+    <% @different_hosts.each do |host| %>
+      <div><%= host.uuid %> - <%= host.name %></div>
+    <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/foreman_wreckingball/hosts/status_managed_hosts_dashboard.html.erb
+++ b/app/views/foreman_wreckingball/hosts/status_managed_hosts_dashboard.html.erb
@@ -15,7 +15,7 @@
 
 <% if @missing_hosts.any? %>
   <div id="missing_vms">
-    <h2>List of hosts missing not found in vSphere</h2>
+    <h2>List of hosts not found in vSphere</h2>
     <div class="list-group list-view-pf list-view-pf-equalized-column" style="max-height: initial;">
     <% @missing_hosts.each do |host| %>
       <div><%= host.name %></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
         end
         collection do
           get :status_dashboard
+          get :status_managed_hosts_dashboard
           get 'status_dashboard/hosts(/:status)', as: :ajax_status_dashboard, action: :status_hosts, defaults: { format: :json }
           put :refresh_status_dashboard
         end

--- a/lib/foreman_wreckingball/engine.rb
+++ b/lib/foreman_wreckingball/engine.rb
@@ -56,6 +56,7 @@ module ForemanWreckingball
         # Extend built in permissions
         Foreman::AccessControl.permission(:view_hosts).actions.concat [
           'foreman_wreckingball/hosts/status_dashboard',
+          'foreman_wreckingball/hosts/status_managed_hosts_dashboard',
           'foreman_wreckingball/hosts/status_hosts'
         ]
 
@@ -65,6 +66,11 @@ module ForemanWreckingball
                                                         :after => :hosts
 
         WRECKINGBALL_STATUSES.each { |status| register_custom_status(status.constantize) }
+
+        menu :top_menu, :wreckingball_status_managed_hosts_dashboard, url_hash: { :controller => :'foreman_wreckingball/hosts', :action => :status_managed_hosts_dashboard },
+                                                                      caption: N_('VMware Managed Status'),
+                                                                      parent: :hosts_menu,
+                                                                      after: :hosts
 
         register_facet(ForemanWreckingball::VmwareFacet, :vmware_facet)
 

--- a/lib/foreman_wreckingball/engine.rb
+++ b/lib/foreman_wreckingball/engine.rb
@@ -69,8 +69,8 @@ module ForemanWreckingball
 
         menu :top_menu, :wreckingball_status_managed_hosts_dashboard, url_hash: { :controller => :'foreman_wreckingball/hosts', :action => :status_managed_hosts_dashboard },
                                                                       caption: N_('VMware Managed Status'),
-                                                                      parent: :hosts_menu,
-                                                                      after: :hosts
+                                                                      parent: :monitor_menu,
+                                                                      after: :audits
 
         register_facet(ForemanWreckingball::VmwareFacet, :vmware_facet)
 

--- a/test/controllers/foreman_wreckingball/hosts_controller_test.rb
+++ b/test/controllers/foreman_wreckingball/hosts_controller_test.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'pry'
+
 require 'test_plugin_helper'
 
 module ForemanWreckingball
@@ -84,6 +86,34 @@ module ForemanWreckingball
             assert_equal expected_4_critical, assigns[:data][3][:counter]
           end
         end
+      end
+    end
+
+    describe '#status_managed_hosts_dashboard' do
+      let(:admin) { users(:admin) }
+
+      setup do
+        @managed_host = FactoryBot.create(:host, :managed, owner: admin, uuid: 1)
+        @missing_host = FactoryBot.create(:host, :managed, owner: admin)
+
+        mock_vm = mock('vm')
+        mock_vm.expects(:uuid).returns(@managed_host.uuid)
+        Foreman::Model::Vmware.any_instance.stubs(:vms).returns(Array(mock_vm))
+      end
+
+      test 'shows a status page' do
+        get :status_managed_hosts_dashboard, session: set_session_user
+        assert_response :success
+      end
+
+      test 'should contain host with missing vm' do
+        get :status_managed_hosts_dashboard, session: set_session_user
+        assert_includes assigns[:missing_hosts], @missing_host
+      end
+
+      test 'should filter host with vm' do
+        get :status_managed_hosts_dashboard, session: set_session_user
+        refute_includes assigns[:missing_hosts], @managed_host
       end
     end
 

--- a/test/controllers/foreman_wreckingball/hosts_controller_test.rb
+++ b/test/controllers/foreman_wreckingball/hosts_controller_test.rb
@@ -96,7 +96,7 @@ module ForemanWreckingball
           :vmware_cr,
           uuid: 'test',
           organizations: [organization],
-          locations: [tax_location],
+          locations: [tax_location]
         )
       end
       let(:other_cr) do
@@ -104,7 +104,7 @@ module ForemanWreckingball
           :vmware_cr,
           uuid: 'bla',
           organizations: [organization],
-          locations: [tax_location],
+          locations: [tax_location]
         )
       end
 

--- a/test/controllers/foreman_wreckingball/hosts_controller_test.rb
+++ b/test/controllers/foreman_wreckingball/hosts_controller_test.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'pry'
-
 require 'test_plugin_helper'
 
 module ForemanWreckingball
@@ -93,7 +91,7 @@ module ForemanWreckingball
       let(:admin) { users(:admin) }
 
       setup do
-        @managed_host = FactoryBot.create(:host, :managed, owner: admin, uuid: 1)
+        @managed_host= FactoryBot.create(:host, :managed, owner: admin, uuid: 1)
         @missing_host = FactoryBot.create(:host, :managed, owner: admin)
 
         mock_vm = mock('vm')
@@ -114,6 +112,12 @@ module ForemanWreckingball
       test 'should filter host with vm' do
         get :status_managed_hosts_dashboard, session: set_session_user
         refute_includes assigns[:missing_hosts], @managed_host
+      end
+
+      describe 'test' do
+        test 'should contain host that references the same vm multiple times' do
+
+        end
       end
     end
 

--- a/test/integration/hosts_status_managed_hosts_test.rb
+++ b/test/integration/hosts_status_managed_hosts_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'pry'
+
+require 'integration_test_plugin_helper'
+
+class HostsStatusManagedHostsTest < ActionDispatch::IntegrationTest
+  setup do
+    Setting::Wreckingball.load_defaults
+  end
+
+  let(:admin) { users(:admin) }
+
+  test 'shows missing host without VMware vm' do
+    managed_host = FactoryBot.create(:host, :managed, owner: admin, uuid: 1)
+    missing_host = FactoryBot.create(:host, :managed, owner: admin)
+
+    mock_vm = mock('vm')
+    mock_vm.expects(:uuid).returns(managed_host.uuid)
+    Foreman::Model::Vmware.any_instance.stubs(:vms).returns(Array(mock_vm))
+
+    visit status_managed_hosts_dashboard_hosts_path
+
+    binding.pry
+  end
+end

--- a/test/integration/hosts_status_managed_hosts_test.rb
+++ b/test/integration/hosts_status_managed_hosts_test.rb
@@ -1,26 +1,83 @@
 # frozen_string_literal: true
 
-require 'pry'
-
 require 'integration_test_plugin_helper'
 
 class HostsStatusManagedHostsTest < ActionDispatch::IntegrationTest
   setup do
     Setting::Wreckingball.load_defaults
+    Fog.mock!
   end
 
+  let(:organization) { Organization.find_by(name: 'Organization 1') }
+  let(:tax_location) { Location.find_by(name: 'Location 1') }
   let(:admin) { users(:admin) }
+  let(:cr) do
+    FactoryBot.create(
+      :vmware_cr,
+      uuid: 'test',
+      organizations: [organization],
+      locations: [tax_location],
+    )
+  end
 
   test 'shows missing host without VMware vm' do
-    managed_host = FactoryBot.create(:host, :managed, owner: admin, uuid: 1)
-    missing_host = FactoryBot.create(:host, :managed, owner: admin)
+    managed_host = FactoryBot.create(:host, :managed, :with_vmware_facet, compute_resource: cr, owner: admin, uuid: 1)
+    missing_host = FactoryBot.create(:host, :managed, :with_vmware_facet, compute_resource: cr, owner: admin, uuid: 2)
 
     mock_vm = mock('vm')
-    mock_vm.expects(:uuid).returns(managed_host.uuid)
+    mock_vm.stubs(:uuid).returns(managed_host.uuid)
+    mock_vm.stubs(:name).returns(managed_host.name)
     Foreman::Model::Vmware.any_instance.stubs(:vms).returns(Array(mock_vm))
 
     visit status_managed_hosts_dashboard_hosts_path
 
-    binding.pry
+    list = page.find('#missing_vms')
+    assert_includes list.text, missing_host.name
+    refute_includes list.text, managed_host.name
+    # refute list.text.contains?(managed_host.name)
+  end
+
+  test 'shows duplicate vms with same uuid for a host' do
+    managed_host = FactoryBot.create(:host, :managed, compute_resource: cr, owner: admin, uuid: 1)
+
+    mock_vm_1 = mock('vm1')
+    mock_vm_1.stubs(:uuid).returns(managed_host.uuid)
+    mock_vm_1.stubs(:name).returns("foo01.example.com")
+    mock_vm_2 = mock('vm2')
+    mock_vm_2.stubs(:uuid).returns(managed_host.uuid)
+    mock_vm_2.stubs(:name).returns("foo02.example.com")
+    Foreman::Model::Vmware.any_instance.stubs(:vms).returns([mock_vm_1, mock_vm_2])
+
+    visit status_managed_hosts_dashboard_hosts_path
+
+    list = page.find('#duplicate_vms')
+    assert_includes list.text, 'foo01.example.com'
+    assert_includes list.text, 'foo02.example.com'
+  end
+
+  test 'shows hosts with vm associated with a different compute resource' do
+    other_cr = FactoryBot.create(
+      :vmware_cr,
+      uuid: 'bla',
+      organizations: [organization],
+      locations: [tax_location],
+    )
+
+    managed_host_1 = FactoryBot.create(:host, :managed, compute_resource: cr, owner: admin, uuid: 2)
+    managed_host_2 = FactoryBot.create(:host, :managed, compute_resource: other_cr, owner: admin, uuid: 1)
+
+    mock_vm_1 = mock('vm1')
+    mock_vm_1.stubs(:uuid).returns(managed_host_1.uuid)
+    mock_vm_1.stubs(:name).returns(managed_host_1.name)
+    mock_vm_2 = mock('vm2')
+    mock_vm_2.stubs(:uuid).returns(managed_host_2.uuid)
+    mock_vm_2.stubs(:name).returns(managed_host_2.name)
+    Foreman::Model::Vmware.any_instance.stubs(:vms).returns([mock_vm_1, mock_vm_2])
+
+    visit status_managed_hosts_dashboard_hosts_path
+
+    list = page.find('#different_vms')
+    assert_includes list.text, managed_host_1.name
+    refute_includes list.text, managed_host_2.name
   end
 end

--- a/test/integration/hosts_status_managed_hosts_test.rb
+++ b/test/integration/hosts_status_managed_hosts_test.rb
@@ -21,8 +21,8 @@ class HostsStatusManagedHostsTest < ActionDispatch::IntegrationTest
   end
 
   test 'shows missing host without VMware vm' do
-    managed_host = FactoryBot.create(:host, :managed, :with_vmware_facet, compute_resource: cr, owner: admin, uuid: 1)
-    missing_host = FactoryBot.create(:host, :managed, :with_vmware_facet, compute_resource: cr, owner: admin, uuid: 2)
+    managed_host = FactoryBot.create(:host, :managed, compute_resource: cr, owner: admin, uuid: 1)
+    missing_host = FactoryBot.create(:host, :managed, compute_resource: cr, owner: admin, uuid: 2)
 
     mock_vm = mock('vm')
     mock_vm.stubs(:uuid).returns(managed_host.uuid)
@@ -62,8 +62,11 @@ class HostsStatusManagedHostsTest < ActionDispatch::IntegrationTest
       locations: [tax_location]
     )
 
-    managed1_host = FactoryBot.create(:host, :managed, compute_resource: cr, owner: admin, uuid: 2)
-    managed2_host = FactoryBot.create(:host, :managed, compute_resource: other_cr, owner: admin, uuid: 1)
+    # Host 2 is associated to other_cr, but shows up on cr
+    # Host 1 and 3 are correctly associated.
+    managed1_host = FactoryBot.create(:host, :managed, compute_resource: cr, owner: admin, uuid: 1)
+    managed2_host = FactoryBot.create(:host, :managed, compute_resource: other_cr, owner: admin, uuid: 2)
+    managed3_host = FactoryBot.create(:host, :managed, compute_resource: other_cr, owner: admin, uuid: 3)
 
     mock1_vm = mock('vm1')
     mock1_vm.stubs(:uuid).returns(managed1_host.uuid)
@@ -71,12 +74,20 @@ class HostsStatusManagedHostsTest < ActionDispatch::IntegrationTest
     mock2_vm = mock('vm2')
     mock2_vm.stubs(:uuid).returns(managed2_host.uuid)
     mock2_vm.stubs(:name).returns(managed2_host.name)
-    Foreman::Model::Vmware.any_instance.stubs(:vms).returns([mock1_vm, mock2_vm])
+    mock3_vm = mock('vm3')
+    mock3_vm.stubs(:uuid).returns(managed3_host.uuid)
+    mock3_vm.stubs(:name).returns(managed3_host.name)
+
+    cr.stubs(:vms).returns([mock1_vm, mock2_vm])
+    other_cr.stubs(:vms).returns([mock3_vm])
+
+    ComputeResource.stubs(:where).returns([cr, other_cr])
 
     visit status_managed_hosts_dashboard_hosts_path
 
     list = page.find('#different_vms')
-    assert_includes list.text, managed1_host.name
-    refute_includes list.text, managed2_host.name
+    refute_includes list.text, managed1_host.name
+    assert_includes list.text, managed2_host.name
+    refute_includes list.text, managed3_host.name
   end
 end

--- a/test/integration/hosts_status_managed_hosts_test.rb
+++ b/test/integration/hosts_status_managed_hosts_test.rb
@@ -34,7 +34,6 @@ class HostsStatusManagedHostsTest < ActionDispatch::IntegrationTest
     list = page.find('#missing_vms')
     assert_includes list.text, missing_host.name
     refute_includes list.text, managed_host.name
-    # refute list.text.contains?(managed_host.name)
   end
 
   test 'shows duplicate vms with same uuid for a host' do

--- a/test/integration/hosts_status_managed_hosts_test.rb
+++ b/test/integration/hosts_status_managed_hosts_test.rb
@@ -16,7 +16,7 @@ class HostsStatusManagedHostsTest < ActionDispatch::IntegrationTest
       :vmware_cr,
       uuid: 'test',
       organizations: [organization],
-      locations: [tax_location],
+      locations: [tax_location]
     )
   end
 
@@ -39,13 +39,13 @@ class HostsStatusManagedHostsTest < ActionDispatch::IntegrationTest
   test 'shows duplicate vms with same uuid for a host' do
     managed_host = FactoryBot.create(:host, :managed, compute_resource: cr, owner: admin, uuid: 1)
 
-    mock_vm_1 = mock('vm1')
-    mock_vm_1.stubs(:uuid).returns(managed_host.uuid)
-    mock_vm_1.stubs(:name).returns("foo01.example.com")
-    mock_vm_2 = mock('vm2')
-    mock_vm_2.stubs(:uuid).returns(managed_host.uuid)
-    mock_vm_2.stubs(:name).returns("foo02.example.com")
-    Foreman::Model::Vmware.any_instance.stubs(:vms).returns([mock_vm_1, mock_vm_2])
+    mock1_vm = mock('vm1')
+    mock1_vm.stubs(:uuid).returns(managed_host.uuid)
+    mock1_vm.stubs(:name).returns('foo01.example.com')
+    mock2_vm = mock('vm2')
+    mock2_vm.stubs(:uuid).returns(managed_host.uuid)
+    mock2_vm.stubs(:name).returns('foo02.example.com')
+    Foreman::Model::Vmware.any_instance.stubs(:vms).returns([mock1_vm, mock2_vm])
 
     visit status_managed_hosts_dashboard_hosts_path
 
@@ -59,24 +59,24 @@ class HostsStatusManagedHostsTest < ActionDispatch::IntegrationTest
       :vmware_cr,
       uuid: 'bla',
       organizations: [organization],
-      locations: [tax_location],
+      locations: [tax_location]
     )
 
-    managed_host_1 = FactoryBot.create(:host, :managed, compute_resource: cr, owner: admin, uuid: 2)
-    managed_host_2 = FactoryBot.create(:host, :managed, compute_resource: other_cr, owner: admin, uuid: 1)
+    managed1_host = FactoryBot.create(:host, :managed, compute_resource: cr, owner: admin, uuid: 2)
+    managed2_host = FactoryBot.create(:host, :managed, compute_resource: other_cr, owner: admin, uuid: 1)
 
-    mock_vm_1 = mock('vm1')
-    mock_vm_1.stubs(:uuid).returns(managed_host_1.uuid)
-    mock_vm_1.stubs(:name).returns(managed_host_1.name)
-    mock_vm_2 = mock('vm2')
-    mock_vm_2.stubs(:uuid).returns(managed_host_2.uuid)
-    mock_vm_2.stubs(:name).returns(managed_host_2.name)
-    Foreman::Model::Vmware.any_instance.stubs(:vms).returns([mock_vm_1, mock_vm_2])
+    mock1_vm = mock('vm1')
+    mock1_vm.stubs(:uuid).returns(managed1_host.uuid)
+    mock1_vm.stubs(:name).returns(managed1_host.name)
+    mock2_vm = mock('vm2')
+    mock2_vm.stubs(:uuid).returns(managed2_host.uuid)
+    mock2_vm.stubs(:name).returns(managed2_host.name)
+    Foreman::Model::Vmware.any_instance.stubs(:vms).returns([mock1_vm, mock2_vm])
 
     visit status_managed_hosts_dashboard_hosts_path
 
     list = page.find('#different_vms')
-    assert_includes list.text, managed_host_1.name
-    refute_includes list.text, managed_host_2.name
+    assert_includes list.text, managed1_host.name
+    refute_includes list.text, managed2_host.name
   end
 end

--- a/test/integration_test_plugin_helper.rb
+++ b/test/integration_test_plugin_helper.rb
@@ -8,3 +8,5 @@ require 'webmock'
 # Add plugin to FactoryBot's paths
 FactoryBot.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
 FactoryBot.reload
+
+WebMock.disable_net_connect!(allow_localhost: true)

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -2,9 +2,25 @@
 
 # This calls the main test_helper in Foreman-core
 require 'test_helper'
+require 'database_cleaner'
 require 'dynflow/testing'
 
 # Add plugin to FactoryBot's paths
 FactoryBot.definition_file_paths << File.join(ForemanTasks::Engine.root, 'test', 'factories')
 FactoryBot.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
 FactoryBot.reload
+
+# Foreman's setup doesn't handle cleaning in plugin
+DatabaseCleaner.strategy = :transaction
+
+module Minitest
+  class Spec
+    before :each do
+      DatabaseCleaner.start
+    end
+
+    after :each do
+      DatabaseCleaner.clean
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new status page, reachable via a option in the sidebar navigation "VMware Managed Status", to show the synched status of managed hosts between Foreman and the VMWare site.

For example if a user modifies / deletes a VM via vSphere, the status of this managed VM may be different than it is in Foreman. The status page checks the list of managed hosts and diplays the difference in information. The following scenarios are listed, when:

* a compute resource id not found, the VM uuid is missing in vSphere
* the host uuid is found, but is associated with a different compute resource
* there exists duplicate hosts for a given host uuid

Not sure if all scenarios are possible to happen. The current state of the status page is, the hosts are listed, but the UI is minimal and requires a bit more attention. This is an area that definitely needs more attention. Furthermore the status page is rendered server side only for now, there is no Ajax function yet to provide asynchronous loading of data via the front end.