### PR TITLE
optimize managed status overview

### DIFF
--- a/app/assets/javascripts/foreman_wreckingball/status_managed_hosts_dashboard.js
+++ b/app/assets/javascripts/foreman_wreckingball/status_managed_hosts_dashboard.js
@@ -1,5 +1,5 @@
 $(document).ready(() => {
-  $('table#missing_vms').add('table#duplicate_vms').add('table#different_vms')
+  $('table#missing_vms').add('table#wrong_hosts').add('table#more_than_one_hosts')
     .DataTable({
       bLengthChange: true,
       lengthMenu: [20, 50, 100],

--- a/app/views/foreman_wreckingball/hosts/_status_managed_hosts_dashboard_cards.html.erb
+++ b/app/views/foreman_wreckingball/hosts/_status_managed_hosts_dashboard_cards.html.erb
@@ -1,16 +1,16 @@
 <div class='status-managed-hosts-dashboard-cards container-fluid container-cards-pf'>
   <div class='row row-cards-pf'>
     <%= render partial: 'status_managed_hosts_dashboard_cards_card', locals: {
-      title: _('List of Hosts not found in vSphere'),
+      title: _('Hosts not found in vSphere'),
       count: missing_hosts_count
     } %>
     <%= render partial: 'status_managed_hosts_dashboard_cards_card', locals: {
-      title: _('List of VMs with same uuid'),
-      count: duplicate_vms_count
+      title: _('Hosts associated to wrong Compute Resource'),
+      count: wrong_hosts_count
     } %>
     <%= render partial: 'status_managed_hosts_dashboard_cards_card', locals: {
-      title: _('List of VMs associated with different compute resources'),
-      count: different_hosts_count
+      title: _('Hosts found on more than one Compute Resource'),
+      count: more_than_one_hosts_count
     } %>
   </div>
 </div>

--- a/app/views/foreman_wreckingball/hosts/status_managed_hosts_dashboard.html.erb
+++ b/app/views/foreman_wreckingball/hosts/status_managed_hosts_dashboard.html.erb
@@ -14,8 +14,8 @@
 
 <%= render partial: 'status_managed_hosts_dashboard_cards', locals: {
   missing_hosts_count: @missing_hosts.count,
-  duplicate_vms_count: @duplicate_vms.map(&:second).flatten.count,
-  different_hosts_count: @different_hosts.count
+  wrong_hosts_count: @wrong_hosts.count,
+  more_than_one_hosts_count: @more_than_one_hosts.count
 } %>
 
 <ul class='nav nav-tabs' data-tabs='tabs'>
@@ -23,17 +23,17 @@
     <%= content_tag :a, _('List of Hosts not found in vSphere'), href: '#missing_vms_tab', 'data-toggle': 'tab' %>
   </li>
   <li>
-    <%= content_tag :a, _('List of VMs with same uuid'), href: '#duplicate_vms_tab', 'data-toggle': 'tab' %>
+    <%= content_tag :a, _('List of Hosts associated to wrong Compute Resource'), href: '#wrong_hosts_tab', 'data-toggle': 'tab' %>
   </li>
   <li>
-    <%= content_tag :a, _('List of VMs associated with different Compute Resources'), href: '#different_vms_tab', 'data-toggle': 'tab' %>
+    <%= content_tag :a, _('List of Hosts found on more than one Compute Resource'), href: '#more_than_one_hosts_tab', 'data-toggle': 'tab' %>
   </li>
 </ul>
 
 <div class='tab-content'>
   <div class='tab-pane active' id='missing_vms_tab'>
     <% if @missing_hosts.empty? %>
-      <%= content_tag :p, _('No hosts to show'), class: 'ca' %>
+      <%= content_tag :p, _('No Hosts to show'), class: 'ca' %>
     <% else %>
       <%= content_tag :table, id: 'missing_vms', class: table_css_classes do %>
         <thead>
@@ -44,53 +44,57 @@
         <tbody>
           <% @missing_hosts.each do |host| %>
             <tr>
-              <%= content_tag :td, link_to_if_authorized(host.name, hash_for_host_path(id: host)) %>
+              <%= content_tag :td, link_to_if_authorized(host.name, hash_for_host_path(id: host).merge(permission: 'view_hosts', auth_object: host, authorizer: @host_authorizer)) %>
             </tr>
           <% end %>
         </tbody>
       <% end %>
     <% end %>
   </div>
-  <div class='tab-pane' id='duplicate_vms_tab'>
-    <% if @duplicate_vms.empty? %>
-      <%= content_tag :p, _('No hosts to show'), class: 'ca' %>
+  <div class='tab-pane' id='wrong_hosts_tab'>
+    <% if @wrong_hosts.empty? %>
+      <%= content_tag :p, _('No Hosts to show'), class: 'ca' %>
     <% else %>
-      <%= content_tag :table, id: 'duplicate_vms', class: table_css_classes do %>
+      <%= content_tag :table, id: 'wrong_hosts', class: table_css_classes do %>
         <thead>
           <tr>
-            <%= content_tag :th, _('UUID') %>
             <%= content_tag :th, _('Name') %>
+            <%= content_tag :th, _('Associated to') %>
+            <%= content_tag :th, _('Found on') %>
           </tr>
         </thead>
         <tbody>
-          <% @duplicate_vms.each do |_uuid, hosts| %>
-            <% hosts.each do |host| %>
-              <tr>
-                <%= content_tag :td, host.uuid %>
-                <%= content_tag :td, link_to_if_authorized(host.name, hash_for_host_path(id: host)) %>
-              </tr>
-            <% end %>
+          <% @wrong_hosts.each do |host| %>
+            <tr>
+              <%= content_tag :td, link_to_if_authorized(host.name, hash_for_host_path(id: host).merge(permission: 'view_hosts', auth_object: host, authorizer: @host_authorizer)) %>
+              <%= content_tag :td, link_to_if_authorized(host.compute_resource.name, hash_for_compute_resource_path(id: host.compute_resource).merge(permission: 'view_compute_resources', auth_object: host.compute_resource, authorizer: @compute_resource_authorizer)) %>
+              <%= content_tag :td, link_to_if_authorized(@vm_compute_resource_mapping[host.uuid].first.name, hash_for_compute_resource_path(id: @vm_compute_resource_mapping[host.uuid].first).merge(permission: 'view_compute_resources', auth_object: @vm_compute_resource_mapping[host.uuid].first, authorizer: @compute_resource_authorizer)) %>
+            </tr>
           <% end %>
         </tbody>
       <% end %>
     <% end %>
   </div>
-  <div class='tab-pane' id='different_vms_tab'>
-    <% if @different_hosts.empty? %>
-      <%= content_tag :p, _('No hosts to show'), class: 'ca' %>
+  <div class='tab-pane' id='more_than_one_hosts_tab'>
+    <% if @more_than_one_hosts.empty? %>
+      <%= content_tag :p, _('No Hosts to show'), class: 'ca' %>
     <% else %>
-      <%= content_tag :table, id: 'different_vms', class: table_css_classes do %>
+      <%= content_tag :table, id: 'more_than_one_hosts', class: table_css_classes do %>
         <thead>
           <tr>
-            <%= content_tag :th, _('UUID') %>
             <%= content_tag :th, _('Name') %>
+            <%= content_tag :th, _('Associated to') %>
+            <%= content_tag :th, _('Found on') %>
           </tr>
         </thead>
         <tbody>
-          <% @different_hosts.each do |host| %>
+          <% @more_than_one_hosts.each do |host| %>
             <tr>
-              <%= content_tag :td, host.uuid %>
-              <%= content_tag :td, link_to_if_authorized(host.name, hash_for_host_path(id: host)) %>
+              <%= content_tag :td, link_to_if_authorized(host.name, hash_for_host_path(id: host).merge(permission: 'view_hosts', auth_object: host, authorizer: authorizer)) %>
+              <%= content_tag :td, (link_to_if_authorized(host.compute_resource.name, hash_for_compute_resource_path(id: host.compute_resource).merge(permission: 'view_compute_resources', auth_object: host.compute_resource, authorizer: @compute_resource_authorizer)) if host.compute_resource) %>
+              <td>
+                <%= safe_join(@vm_compute_resource_mapping[host.uuid].map { |compute_resource| link_to_if_authorized(compute_resource.name, hash_for_compute_resource_path(id: compute_resource).merge(permission: 'view_compute_resources', auth_object: compute_resource, authorizer: @compute_resource_authorizer))}, ', ') %>
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/test/controllers/foreman_wreckingball/hosts_controller_test.rb
+++ b/test/controllers/foreman_wreckingball/hosts_controller_test.rb
@@ -116,9 +116,9 @@ module ForemanWreckingball
         @missing_host = FactoryBot.create(:host, :managed, :with_vmware_facet, compute_resource: cr, owner: admin, uuid: 2)
 
         mock_vm = mock('vm')
-        mock_vm.stubs(:uuid).returns(@managed_host.uuid)
+        mock_vm.stubs(:id).returns(@managed_host.uuid)
         mock_vm.stubs(:name).returns(@managed_host.name)
-        Foreman::Model::Vmware.any_instance.stubs(:vms).returns(Array(mock_vm))
+        Foreman::Model::Vmware.any_instance.stubs(:vms).returns(OpenStruct.new(all: Array(mock_vm)))
       end
 
       test 'shows a status page' do

--- a/test/integration_test_plugin_helper.rb
+++ b/test/integration_test_plugin_helper.rb
@@ -6,6 +6,7 @@ require 'webmock/minitest'
 require 'webmock'
 
 # Add plugin to FactoryBot's paths
+FactoryBot.definition_file_paths << File.join(ForemanTasks::Engine.root, 'test', 'factories')
 FactoryBot.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
 FactoryBot.reload
 


### PR DESCRIPTION
This PR optimized the managed status overview page.
- it loads VMs faster by using Foreman's MiniServer classes instead of full fog objects
- it makes the different lists easier to understand
- it shows more details to the mismatching compute resources
- it fully relies on host objects so we can always link to the host page
- it drops the UUID column as it's not very human-friendly