### PR TITLE
travis: test core develop with ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,18 @@ language: ruby
 cache:
   - npm
   - bundler
-rvm:
-  - 2.3
 install:
   - unset BUNDLE_GEMFILE
   - cd ..
   - git clone https://github.com/theforeman/foreman.git -b ${FOREMAN_CORE_BRANCH} --depth 1
+  - git clone https://github.com/theforeman/foreman-tasks.git -b ${FOREMAN_TASKS_BRANCH} --depth 1
   - cd ${FOREMAN_PLUGIN_NAME}
   - bundle install --jobs=3 --retry=3
   - npm install eslint
   - cd ../foreman
   - echo "gemspec :path => '../${FOREMAN_PLUGIN_NAME}'" > bundler.d/${FOREMAN_PLUGIN_NAME}.local.rb
+  - echo "gem 'foreman-tasks-core', :path => '../foreman-tasks'" > bundler.d/foreman-tasks.local.rb
+  - echo "gem 'foreman-tasks', :path => '../foreman-tasks'" >> bundler.d/foreman-tasks.local.rb
   - ln -s settings.yaml.test config/settings.yaml
   - ln -s database.yml.example config/database.yml
   - bundle install --jobs=3 --retry=3 --without journald development postgresql mysql2 console journald
@@ -31,9 +32,16 @@ env:
   global:
     - TESTOPTS=-v
     - FOREMAN_PLUGIN_NAME=foreman_wreckingball
-  matrix:
-    - FOREMAN_CORE_BRANCH=1.21-stable
-    - FOREMAN_CORE_BRANCH=develop
+jobs:
+  include:
+  - rvm: 2.5
+    env:
+      - FOREMAN_CORE_BRANCH=develop
+      - FOREMAN_TASKS_BRANCH='master'
+  - rvm: 2.3
+    env:
+      - FOREMAN_CORE_BRANCH=1.21-stable
+      - FOREMAN_TASKS_BRANCH='0.14.x'
 addons:
   apt:
     packages:


### PR DESCRIPTION
The current develop branch of Foreman core requires at least ruby 2.5, see https://github.com/theforeman/foreman/pull/7292.