### PR TITLE
Make sure rake tasks run as Dynflow clients

### DIFF
--- a/lib/tasks/foreman_vmware_checks_tasks.rake
+++ b/lib/tasks/foreman_vmware_checks_tasks.rake
@@ -6,7 +6,7 @@ require 'rake/testtask'
 namespace :foreman_wreckingball do
   namespace :vmware do
     desc 'Synchonize VMware compute resource data'
-    task :sync => :environment do
+    task :sync => ['environment', 'dynflow:client'] do
       User.as_anonymous_admin do
         ::ForemanTasks.sync_task(::Actions::ForemanWreckingball::Vmware::ScheduleVmwareSync)
       end


### PR DESCRIPTION
Fixes a bug where the rake task would not run due to dynflow world not being initialized

This relates to https://github.com/theforeman/foreman-tasks/pull/559