### PR TITLE
Drop Foreman 2.2 and below and explicitly support 2.3 onwards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,70 +30,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        foreman-core-branch: [1.24-stable, 2.0-stable, 2.1-stable, 2.2-stable, 2.3-stable, 2.4-stable, develop]
-        foreman-tasks-branch: [0.15.x, 0.16.x, 0.17.x, 1.1.x, 2.0.x, 3.0.x, master]
-        ruby-version: [2.5, 2.6]
+        foreman-core-branch: [2.3-stable, 2.4-stable, 2.5-stable, develop]
+        foreman-tasks-branch: [3.0.x, 4.0.x, master]
+        ruby-version: [2.5, 2.6, 2.7]
         node-version: [10]
         exclude:
-          # 1.24-stable
-          - foreman-core-branch: 1.24-stable
-            foreman-tasks-branch: 1.1.x
-          - foreman-core-branch: 1.24-stable
-            foreman-tasks-branch: 2.0.x
-          - foreman-core-branch: 1.24-stable
-            foreman-tasks-branch: 3.0.x
-          - foreman-core-branch: 1.24-stable
-            foreman-tasks-branch: master
-          # 2.0-stable
-          - foreman-core-branch: 2.0-stable
-            foreman-tasks-branch: 2.0.x
-          - foreman-core-branch: 2.0-stable
-            foreman-tasks-branch: 3.0.x
-          - foreman-core-branch: 2.0-stable
-            foreman-tasks-branch: master
-          # 2.1-stable
-          - foreman-core-branch: 2.1-stable
-            foreman-tasks-branch: 0.15.x
-          - foreman-core-branch: 2.1-stable
-            foreman-tasks-branch: 0.16.x
-          - foreman-core-branch: 2.1-stable
-            foreman-tasks-branch: 0.17.x
-          - foreman-core-branch: 2.1-stable
-            foreman-tasks-branch: 3.0.x
-          - foreman-core-branch: 2.1-stable
-            foreman-tasks-branch: master
-          # 2.2-stable
-          - foreman-core-branch: 2.2-stable
-            foreman-tasks-branch: 0.15.x
-          - foreman-core-branch: 2.2-stable
-            foreman-tasks-branch: 0.16.x
-          - foreman-core-branch: 2.2-stable
-            foreman-tasks-branch: 0.17.x
-          - foreman-core-branch: 2.2-stable
-            foreman-tasks-branch: master
           # 2.3-stable
           - foreman-core-branch: 2.3-stable
-            foreman-tasks-branch: 0.15.x
-          - foreman-core-branch: 2.3-stable
-            foreman-tasks-branch: 0.16.x
-          - foreman-core-branch: 2.3-stable
-            foreman-tasks-branch: 0.17.x
+            foreman-tasks-branch: 4.0.x
           - foreman-core-branch: 2.3-stable
             foreman-tasks-branch: master
           # 2.4-stable
           - foreman-core-branch: 2.4-stable
-            foreman-tasks-branch: 0.15.x
-          - foreman-core-branch: 2.4-stable
-            foreman-tasks-branch: 0.16.x
-          - foreman-core-branch: 2.4-stable
-            foreman-tasks-branch: 0.17.x
-          # develop
-          - foreman-core-branch: develop
-            foreman-tasks-branch: 0.15.x
-          - foreman-core-branch: develop
-            foreman-tasks-branch: 0.16.x
-          - foreman-core-branch: develop
-            foreman-tasks-branch: 0.17.x
+            foreman-tasks-branch: master
+          # 2.5-stable
+          - foreman-core-branch: 2.5-stable
+            foreman-tasks-branch: master
     steps:
       - name: Install dependencies
         run: |
@@ -127,11 +79,15 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+      - name: Include foreman-tasks-core for old foreman-tasks versions
+        if: ${{ matrix.foreman-tasks-branch == '3.0.x' || matrix.foreman-tasks-branch == '4.0.x' }}
+        working-directory: foreman
+        run: |
+          echo "gem 'foreman-tasks-core', path: '../foreman-tasks'" > bundler.d/foreman-tasks-core.local.rb
       - name: Setup Bundler
         working-directory: foreman
         run: |
           echo "gem 'foreman_wreckingball', path: '../foreman_wreckingball'" > bundler.d/foreman_wreckingball.local.rb
-          echo "gem 'foreman-tasks-core', path: '../foreman-tasks'" > bundler.d/foreman-tasks-core.local.rb
           echo "gem 'foreman-tasks', path: '../foreman-tasks'" > bundler.d/foreman-tasks.local.rb
           gem install bundler
           bundle config path vendor/bundle

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is a plugin for Foreman that adds several VMware related status checks to y
 | >= 1.16         | ~> 1.0         |
 | >= 1.17         | ~> 2.0         |
 | >= 1.21         | ~> 3.0         |
+| >= 2.3          | ~> 4.0         |
 
 ## Installation
 

--- a/foreman_wreckingball.gemspec
+++ b/foreman_wreckingball.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib,locale}/**/*'] + ['LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'foreman-tasks', '>= 0.13.1'
+  s.add_dependency 'foreman-tasks', '>= 3.0.0'
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'rubocop', '0.54.0'
 end

--- a/lib/foreman_wreckingball/engine.rb
+++ b/lib/foreman_wreckingball/engine.rb
@@ -42,7 +42,7 @@ module ForemanWreckingball
 
     initializer 'foreman_wreckingball.register_plugin', :before => :finisher_hook do |_app|
       Foreman::Plugin.register :foreman_wreckingball do
-        requires_foreman '>= 1.24'
+        requires_foreman '>= 2.3'
 
         automatic_assets(false)
         precompile_assets(


### PR DESCRIPTION
This PR also fixes the tests with current `master` of `foreman-tasks`.