### PR TITLE
Prevent renaming of existing virt-who hosts

### DIFF
--- a/test/unit/foreman_wreckingball/vmware_hypervisor_importer_test.rb
+++ b/test/unit/foreman_wreckingball/vmware_hypervisor_importer_test.rb
@@ -74,11 +74,11 @@ module ForemanWreckingball
         assert_not_nil Host::Managed.find_by(id: host_on_other_cluster.id).vmware_hypervisor_facet
       end
 
-      test 'updates host by katello name' do
+      test 'does not touch hosts created by katello/virt-who' do
         host = FactoryBot.create(:host,  organization: organization)
         host.update!(:name => "virt-who-host1.example.com-#{organization.id}")
         importer.import!
-        assert_equal 'host1.example.com', host.reload.name
+        assert_equal "virt-who-host1.example.com-#{organization.id}", host.reload.name
       end
     end
   end


### PR DESCRIPTION
**Current behaviour:**
Virt-Who creates a host for each hypervisor found, which gets named `virt-who-<hostname>-<orgid>`. If the wreckingball rake task runs, it renames these host to `<hostname>`. Afterwards, virt-who will recreate the virt-who host with it's original name.

This causes confusion because the same host is updated/managed by both virt-who and this plugin. Also, this might cause some subscription discrepancies due to the associated content host managed by virt-who. 

**New behaviour:**
This change will separate those concerns and will result in foreman_wreckingball only managing it's "own host" for a given hypervisor.
The virt-who Host will still be created (if virt-who is running) and used for subscription-management.