### PR TITLE
feat(actions): switch to upstream CI templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,138 +1,35 @@
-name: CI
-on: [push, pull_request]
-env:
-  RAILS_ENV: test
-  DATABASE_URL: postgresql://postgres:@localhost/test
-  DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: true
+name: Ruby test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.ref_name }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
+  rubocop:
+    uses: theforeman/actions/.github/workflows/rubocop.yml@v0
+    with:
+      command: bundle exec rubocop --parallel --format github
+
   test:
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:12.1
-        ports: ["5432:5432"]
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    name: Ruby
+    needs: rubocop
     strategy:
       fail-fast: false
       matrix:
-        foreman-core-branch:
-          - 3.1-stable
-          - 3.2-stable
-          - 3.3-stable
-          - 3.4-stable
-          - 3.5-stable
-          - 3.6-stable
-          - 3.7-stable
-          - 3.8-stable
-          - 3.9-stable
-          - develop
-        ruby-version: [2.7]
-        node-version: [14]
-        include:
-          - foreman-core-branch: 3.1-stable
-            foreman-puppet-version: 2.0.7
-            foreman-tasks-version: 5.3.0
-          - foreman-core-branch: 3.2-stable
-            foreman-puppet-version: 3.0.7
-            foreman-tasks-version: 6.0.3
-          - foreman-core-branch: 3.3-stable
-            foreman-puppet-version: 4.0.4
-            foreman-tasks-version: 7.2.1
-          - foreman-core-branch: 3.4-stable
-            foreman-puppet-version: 4.1.1
-            foreman-tasks-version: 7.2.1
-          - foreman-core-branch: 3.5-stable
-            foreman-puppet-version: 5.1.3
-            foreman-tasks-version: 7.2.1
-          - foreman-core-branch: 3.6-stable
-            foreman-puppet-version: 5.1.3
-            foreman-tasks-version: 7.2.1
-          - foreman-core-branch: 3.7-stable
-            foreman-puppet-version: 6.2.0
-            foreman-tasks-version: 8.3.3
-          - foreman-core-branch: 3.8-stable
-            foreman-puppet-version: 6.2.0
-            foreman-tasks-version: 8.3.3
-          - foreman-core-branch: 3.9-stable
-            foreman-puppet-version: 6.2.0
-            foreman-tasks-version: 9.0.2
-          - foreman-core-branch: develop
-            foreman-puppet-version: 6.2.0
-            foreman-tasks-version: 9.0.2
-    steps:
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install build-essential libcurl4-openssl-dev libvirt-dev ruby-libvirt zlib1g-dev libpq-dev
-      - uses: actions/checkout@v3
-        with:
-          repository: theforeman/foreman
-          ref: ${{ matrix.foreman-core-branch }}
-          path: foreman
-          fetch-depth: 0
-      - uses: actions/checkout@v3
-        with:
-          path: foreman_wreckingball
-      - name: Apply patches for Foreman < 3.2
-        if: ${{ contains(fromJson('["3.1-stable"]'), matrix.foreman-core-branch) }}
-        run: |
-          git cherry-pick -n b1f03b375e18c8da498ba0944b2565f53441833c # use minitest-reporters (required for the following PRs on Foreman 3.0 and 3.1; see https://github.com/theforeman/foreman/pull/8960)
-        working-directory: foreman
-      - name: Apply patches for Foreman < 3.3
-        if: ${{ contains(fromJson('["3.1-stable", "3.2-stable"]'), matrix.foreman-core-branch) }}
-        run: |
-          git cherry-pick -n f9cbe74d09c1244821553ef86aecc8e52cab9150 # Remove duplicate puma gem declaration (see https://github.com/theforeman/foreman/pull/9154)
-          git cherry-pick -n a439e1e92e9f98f3dbc8ed2f204bd53cc861565e # pin rack-test to < 2.0 (see https://github.com/theforeman/foreman/pull/9288)
-          git cherry-pick -n c3c697fa131aa54c11918bcc563a7789f3c08ef7 # drop rack-test and bump show_me_the_cookies to ~ 6.0 (see https://github.com/theforeman/foreman/pull/9353)
-        working-directory: foreman
-      - name: Apply patches for Foreman >= 3.2 and <= 3.7
-        if: ${{ contains(fromJson('["3.2-stable", "3.3-stable", "3.4-stable", "3.5-stable", "3.6-stable", "3.7-stable"]'), matrix.foreman-core-branch) }}
-        run: |
-          git cherry-pick -n 1c3a4155f286352e0abbf0d0b298e47e81c2d6c5 # Pin minitest < 5.19 to resolve test failures (see https://github.com/theforeman/foreman/pull/9781)
-        working-directory: foreman
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: true
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Add foreman_puppet
-        working-directory: foreman
-        run: echo "gem 'foreman_puppet', '~> ${{ matrix.foreman-puppet-version }}'" > bundler.d/foreman_puppet.local.rb
-      - name: Add foreman-tasks
-        working-directory: foreman
-        run: echo "gem 'foreman-tasks', '~> ${{ matrix.foreman-tasks-version }}'" > bundler.d/foreman-tasks.local.rb
-      - name: Setup Bundler
-        working-directory: foreman
-        run: |
-          echo "gem 'foreman_wreckingball', path: '../foreman_wreckingball'" > bundler.d/foreman_wreckingball.local.rb
-          gem install bundler -v 2.4.22
-          bundle config path vendor/bundle
-          bundle config set without journald development console mysql2 sqlite
-          bundle lock --update
-      - name: Setup Plugin
-        working-directory: foreman
-        run: |
-          bundle install --jobs=3 --retry=3
-          bundle exec rake db:create
-          bundle exec rake db:migrate
-          npm install
-          bundle exec rake webpack:compile
-      - name: Run rubocop
-        working-directory: foreman
-        run: bundle exec rake foreman_wreckingball:rubocop
-        if: ${{ matrix.foreman-core-branch == 'develop' }}
-      - name: Run plugin tests
-        working-directory: foreman
-        run: bundle exec rake test:foreman_wreckingball
-      - name: Run permissions tests
-        working-directory: foreman
-        run: bundle exec rake test TEST="test/unit/foreman/access_permissions_test.rb"
-      - name: Precompile plugin assets
-        working-directory: foreman
-        run: bundle exec rake 'plugin:assets:precompile[foreman_wreckingball]'
-        env:
-          RAILS_ENV: production
+        foreman:
+          - "develop"
+          - "3.9-stable"
+          - "3.8-stable"
+          - "3.7-stable"
+    uses: theforeman/actions/.github/workflows/foreman_plugin.yml@v0
+    with:
+      plugin: foreman_wreckingball
+      foreman_version: ${{ matrix.foreman }}
+      environment_variables: |
+        FOREMAN_VERSION=${{ matrix.foreman }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,19 @@ Metrics/ClassLength:
     - 'app/services/foreman_wreckingball/vmware_hypervisor_importer.rb'
     - 'lib/foreman_wreckingball/engine.rb'
     - 'test/**/*'
+
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - Rakefile
+
+Metrics/AbcSize:
+  Exclude:
+    - db/**/*
+
+Metrics/MethodLength:
+  Exclude:
+    - db/**/*
+
+Rails/ApplicationRecord:
+  Exclude:
+    - db/**/*

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
-APP_RAKEFILE = File.expand_path('../test/dummy/Rakefile', __FILE__)
+APP_RAKEFILE = File.expand_path('test/dummy/Rakefile', __dir__)
 
 Bundler::GemHelper.install_tasks
 
@@ -38,7 +38,7 @@ task default: :test
 begin
   require 'rubocop/rake_task'
   RuboCop::RakeTask.new
-rescue => _
+rescue LoadError
   puts 'Rubocop not loaded.'
 end
 

--- a/app/models/concerns/foreman_wreckingball/host_extensions.rb
+++ b/app/models/concerns/foreman_wreckingball/host_extensions.rb
@@ -9,7 +9,7 @@ module ForemanWreckingball
       ForemanWreckingball::Engine::WRECKINGBALL_STATUSES.map(&:constantize).each do |status|
         has_one(
           status.host_association,
-          class_name: status.to_s, # rubocop:disable Rails/ReflectionClassName
+          class_name: status.to_s,
           foreign_key: 'host_id',
           inverse_of: :host,
           dependent: :destroy

--- a/app/models/concerns/foreman_wreckingball/vmware_facet_host_extensions.rb
+++ b/app/models/concerns/foreman_wreckingball/vmware_facet_host_extensions.rb
@@ -14,40 +14,40 @@ module ForemanWreckingball
       before_provision :queue_vmware_facet_refresh
 
       scoped_search on: :hardware_version,
-                    relation: :vmware_facet,
-                    rename: :vsphere_hardware_version,
-                    complete_value: true,
-                    only_explicit: true
+        relation: :vmware_facet,
+        rename: :vsphere_hardware_version,
+        complete_value: true,
+        only_explicit: true
       scoped_search on: :guest_id,
-                    relation: :vmware_facet,
-                    rename: :vsphere_guest_id,
-                    complete_value: true,
-                    only_explicit: true
+        relation: :vmware_facet,
+        rename: :vsphere_guest_id,
+        complete_value: true,
+        only_explicit: true
       scoped_search on: :cpus,
-                    relation: :vmware_facet,
-                    rename: :vsphere_cpus,
-                    complete_value: true,
-                    only_explicit: true
+        relation: :vmware_facet,
+        rename: :vsphere_cpus,
+        complete_value: true,
+        only_explicit: true
       scoped_search on: :corespersocket,
-                    relation: :vmware_facet,
-                    rename: :vsphere_corespersocket,
-                    complete_value: true,
-                    only_explicit: true
+        relation: :vmware_facet,
+        rename: :vsphere_corespersocket,
+        complete_value: true,
+        only_explicit: true
       scoped_search on: :memory_mb,
-                    relation: :vmware_facet,
-                    rename: :vsphere_memory_mb,
-                    complete_value: true,
-                    only_explicit: true
+        relation: :vmware_facet,
+        rename: :vsphere_memory_mb,
+        complete_value: true,
+        only_explicit: true
       scoped_search on: :power_state,
-                    relation: :vmware_facet,
-                    rename: :vsphere_power_state,
-                    only_explicit: true,
-                    complete_value: ForemanWreckingball::VmwareFacet::VALID_POWER_STATES.map { |status| [status, ForemanWreckingball::VmwareFacet.power_states[status]] }.to_h # rubocop:todo Rails/IndexWith, Layout/LineLength
+        relation: :vmware_facet,
+        rename: :vsphere_power_state,
+        only_explicit: true,
+        complete_value: ForemanWreckingball::VmwareFacet::VALID_POWER_STATES.map { |status| [status, ForemanWreckingball::VmwareFacet.power_states[status]] }.to_h # rubocop:todo Rails/IndexWith, Layout/LineLength
       scoped_search on: :tools_state,
-                    relation: :vmware_facet,
-                    rename: :vsphere_tools_state,
-                    only_explicit: true,
-                    complete_value: ForemanWreckingball::VmwareFacet::VALID_GUEST_STATUSES.map { |status| [status, ForemanWreckingball::VmwareFacet.tools_states[status]] }.to_h # rubocop:todo Rails/IndexWith, Layout/LineLength
+        relation: :vmware_facet,
+        rename: :vsphere_tools_state,
+        only_explicit: true,
+        complete_value: ForemanWreckingball::VmwareFacet::VALID_GUEST_STATUSES.map { |status| [status, ForemanWreckingball::VmwareFacet.tools_states[status]] }.to_h # rubocop:todo Rails/IndexWith, Layout/LineLength
     end
     # rubocop:enable Metrics/BlockLength
 

--- a/app/services/foreman_wreckingball/vmware_hypervisor_importer.rb
+++ b/app/services/foreman_wreckingball/vmware_hypervisor_importer.rb
@@ -33,10 +33,10 @@ module ForemanWreckingball
 
       ipaddress6 = hypervisor.ipaddress6
       ipaddress6 = nil if begin
-                            IPAddr.new('fe80::/10').include?(ipaddress6)
-                          rescue StandardError
-                            false
-                          end
+        IPAddr.new('fe80::/10').include?(ipaddress6)
+      rescue StandardError
+        false
+      end
 
       hostname = hypervisor.hostname
       domainname = hypervisor.domainname
@@ -79,7 +79,7 @@ module ForemanWreckingball
       @hypervisors[cluster.name.to_sym] ||= compute_resource.hypervisors(cluster_id: cluster.name)
     end
 
-    def find_host_for_hypervisor(hypervisor)
+    def find_host_for_hypervisor(hypervisor) # rubocop:disable Metrics/AbcSize
       name = ::ForemanWreckingball::VmwareHypervisorFacet.sanitize_name(hypervisor.name)
       hostname = ::ForemanWreckingball::VmwareHypervisorFacet.sanitize_name([hypervisor.hostname,
                                                                              hypervisor.domainname].join('.'))

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require Rails.root.join('config', 'environments', 'production.rb')
+require Rails.root.join('config/environments/production.rb')
 
 Foreman::Application.configure do
   config.assets.js_compressor = Uglifier.new(harmony: true) if defined?(Uglifier)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,12 +2,13 @@
 
 Rails.application.routes.draw do
   scope '/wreckingball' do
-    constraints(:id => /[^\/]+/) do
+    constraints(id: %r{[^/]+}) do
       resources :hosts, controller: 'foreman_wreckingball/hosts', only: [] do
         collection do
           get :status_dashboard
           get :status_managed_hosts_dashboard
-          get 'status_dashboard/hosts(/:status)', as: :ajax_status_dashboard, action: :status_hosts, defaults: { format: :json }
+          get 'status_dashboard/hosts(/:status)', as: :ajax_status_dashboard, action: :status_hosts,
+defaults: { format: :json }
           put :refresh_status_dashboard
           get :schedule_remediate
           post :submit_remediate

--- a/db/migrate/20181021111543_add_indexes_to_vmware_hypervisor_facets.rb
+++ b/db/migrate/20181021111543_add_indexes_to_vmware_hypervisor_facets.rb
@@ -3,6 +3,6 @@
 class AddIndexesToVmwareHypervisorFacets < ActiveRecord::Migration[5.1]
   def change
     add_index :vmware_hypervisor_facets, :uuid
-    add_index :vmware_hypervisor_facets, [:vmware_cluster_id, :uuid]
+    add_index :vmware_hypervisor_facets, %i[vmware_cluster_id uuid]
   end
 end

--- a/db/migrate/20240201094513_fix_wreckingball_settings_category_to_dsl.rb
+++ b/db/migrate/20240201094513_fix_wreckingball_settings_category_to_dsl.rb
@@ -6,6 +6,8 @@ class FixWreckingballSettingsCategoryToDsl < ActiveRecord::Migration[6.0]
   end
 
   def up
-    MigrationSettings.where(category: 'Setting::Wreckingball').update_all(category: 'Setting') if column_exists?(:settings, :category)
+    MigrationSettings.where(category: 'Setting::Wreckingball').update_all(category: 'Setting') if column_exists?(
+      :settings, :category
+    )
   end
 end

--- a/foreman_wreckingball.gemspec
+++ b/foreman_wreckingball.gemspec
@@ -13,11 +13,20 @@ Gem::Specification.new do |s|
   # also update locale/gemspec.rb
   s.description = 'Adds status checks of the VMWare VMs to Foreman.'
 
+  s.required_ruby_version = '>= 2.5', '< 4'
+
   s.files = Dir['{app,config,db,lib,locale}/**/*'] + ['LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'foreman_puppet'
-  s.add_dependency 'foreman-tasks', '>= 3.0.0'
+
+  case ENV['FOREMAN_VERSION']
+  when '3.7-stable', '3.8-stable'
+    s.add_dependency 'foreman-tasks', '>= 8.0.0', '< 9.0.0'
+  else
+    s.add_dependency 'foreman-tasks'
+  end
+
   s.add_development_dependency 'rdoc'
-  s.add_development_dependency 'rubocop', '0.54.0'
+  s.add_development_dependency 'theforeman-rubocop', '~> 0.1.2'
 end

--- a/lib/tasks/foreman_vmware_checks_tasks.rake
+++ b/lib/tasks/foreman_vmware_checks_tasks.rake
@@ -6,7 +6,7 @@ require 'rake/testtask'
 namespace :foreman_wreckingball do
   namespace :vmware do
     desc 'Synchonize VMware compute resource data'
-    task :sync => ['environment', 'dynflow:client'] do
+    task sync: ['environment', 'dynflow:client'] do
       User.as_anonymous_admin do
         ::ForemanTasks.sync_task(::Actions::ForemanWreckingball::Vmware::ScheduleVmwareSync)
       end
@@ -27,23 +27,16 @@ namespace :test do
 end
 
 namespace :foreman_wreckingball do
-  task :rubocop do
-    begin
-      require 'rubocop/rake_task'
-      RuboCop::RakeTask.new(:rubocop_foreman_wreckingball) do |task|
-        task.patterns = ["#{ForemanWreckingball::Engine.root}/app/**/*.rb",
-                         "#{ForemanWreckingball::Engine.root}/lib/**/*.rb",
-                         "#{ForemanWreckingball::Engine.root}/test/**/*.rb"]
-      end
-    rescue StandardError
-      puts 'Rubocop not loaded.'
-    end
-
-    Rake::Task['rubocop_foreman_wreckingball'].invoke
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new(:rubocop) do |task|
+    task.patterns = ["#{ForemanWreckingball::Engine.root}/app/**/*.rb",
+                     "#{ForemanWreckingball::Engine.root}/lib/**/*.rb",
+                     "#{ForemanWreckingball::Engine.root}/test/**/*.rb"]
   end
+rescue LoadError => e
+  raise e unless Rails.env.production?
 end
 
 Rake::Task[:test].enhance ['test:foreman_wreckingball']
 
-load 'tasks/jenkins.rake'
-Rake::Task['jenkins:unit'].enhance ['test:foreman_wreckingball', 'foreman_wreckingball:rubocop'] if Rake::Task.task_defined?(:'jenkins:unit')
+require 'rubocop/rake_task'

--- a/test/actions/foreman_wreckingball/host/remediate_vmware_operatingsystem_test.rb
+++ b/test/actions/foreman_wreckingball/host/remediate_vmware_operatingsystem_test.rb
@@ -26,7 +26,7 @@ module Actions
         let(:operatingsystem) do
           FactoryBot.create(
             :operatingsystem,
-            architectures: [architectures(:x86_64)],
+            architectures: [architectures(:x86_64)], # rubocop:disable Naming/VariableNumber
             major: 6,
             minor: 1,
             type: 'Redhat',
@@ -39,7 +39,7 @@ module Actions
             :host,
             :managed,
             :with_vmware_facet,
-            architecture: architectures(:x86_64),
+            architecture: architectures(:x86_64), # rubocop:disable Naming/VariableNumber
             operatingsystem: operatingsystem,
             compute_resource: compute_resource,
             uuid: uuid

--- a/test/models/foreman_wreckingball/operatingsystem_status_test.rb
+++ b/test/models/foreman_wreckingball/operatingsystem_status_test.rb
@@ -13,7 +13,7 @@ module ForemanWreckingball
     let(:operatingsystem) do
       FactoryBot.create(
         :operatingsystem,
-        architectures: [architectures(:x86_64)],
+        architectures: [architectures(:x86_64)], # rubocop:disable Naming/VariableNumber
         major: 6,
         minor: 1,
         type: 'Redhat',
@@ -25,7 +25,7 @@ module ForemanWreckingball
         :host,
         :managed,
         :with_vmware_facet,
-        architecture: architectures(:x86_64),
+        architecture: architectures(:x86_64), # rubocop:disable Naming/VariableNumber
         operatingsystem: operatingsystem
       )
     end


### PR DESCRIPTION
- drop tests for Foreman <= 3.5 (as it does not support the template)
- switch generic rubocop for theforeman-rubocop
- fix rubocop warnings