### PR TITLE
drop Foreman 3.7 and 3.8 / add Foreman 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,8 @@ jobs:
       matrix:
         foreman:
           - "develop"
+          - "3.10-stable"
           - "3.9-stable"
-          - "3.8-stable"
-          - "3.7-stable"
     uses: theforeman/actions/.github/workflows/foreman_plugin.yml@v0
     with:
       plugin: foreman_wreckingball

--- a/gemfile.d/tasks.rb
+++ b/gemfile.d/tasks.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-case ENV['FOREMAN_VERSION']
-when '3.7-stable', '3.8-stable'
-  gem 'foreman-tasks', '~> 8.0'
-end


### PR DESCRIPTION
3.7 and 3.8 are EoL and will no longer receive any updates.